### PR TITLE
Add opam file

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Justus Matthiesen <justus.matthiesen@cl.cam.ac.uk>"
+authors: ["Daniel de Rauglaudre"]
+homepage: "https://camlp5.github.io"
+license: "BSD-3-Clause"
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+available: [ocaml-version >= "1.07" & ocaml-version <= "4.04.1"]
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+dev-repo: "https://github.com/camlp5/camlp5"
+doc: "https://camlp5.github.io/doc/html"
+install: [make "install"]


### PR DESCRIPTION
Add an `opam` file so that `opam pin` can be used (see #3).  The compiler constraint is

    available: [ocaml-version >= "1.07" & ocaml-version <= "4.04.1"]

This should be updated as necessary in the future.