### PR TITLE
Install ast2pt.cmi

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -70,8 +70,8 @@ install:
 	-$(MKDIR) "$(DESTDIR)$(BINDIR)"
 	-$(MKDIR) "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)"
 	cp $(CAMLP5) "$(DESTDIR)$(BINDIR)/."
-	cp mLast.mli quotation.mli pcaml.mli prtools.mli reloc.mli "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
-	cp mLast.cmi quotation.cmi pcaml.cmi prtools.cmi reloc.cmi "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
+	cp ast2pt.mli mLast.mli quotation.mli pcaml.mli prtools.mli reloc.mli "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
+	cp ast2pt.cmi mLast.cmi quotation.cmi pcaml.cmi prtools.cmi reloc.cmi "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	cp $(CAMLP5N).cma "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	if test -f $(CAMLP5N).cmxa; then \
 	  cp $(CAMLP5N).cmxa "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."; \


### PR DESCRIPTION
We are working on a syntax extension which should support both camlp5 and PPX. And we need there to convert Camlp5 syntax tree to the OCaml one, so we need a few functions from `Ast2pt` module. Do you have something against installing two extra files?