### PR TITLE
 Support nonrec type declaration in revised and normal syntaxes 

### DIFF
--- a/etc/pa_o.ml
+++ b/etc/pa_o.ml
@@ -412,8 +412,8 @@ EXTEND
           <:str_item< module type $_:i$ = $mt$ >>
       | "open"; i = V mod_ident "list" "" ->
           <:str_item< open $_:i$ >>
-      | "type"; tdl = V (LIST1 type_decl SEP "and") ->
-          <:str_item< type $_list:tdl$ >>
+      | "type"; nr = V (FLAG "nonrec"); tdl = V (LIST1 type_decl SEP "and") ->
+          <:str_item< type $_flag:nr$ $_list:tdl$ >>
       | "let"; r = V (FLAG "rec"); l = V (LIST1 let_binding SEP "and"); "in";
         x = expr ->
           let e = <:expr< let $_flag:r$ $_list:l$ in $x$ >> in

--- a/etc/pa_pragma.ml
+++ b/etc/pa_pragma.ml
@@ -811,8 +811,8 @@ value val_tab = do {
       fun loc ->
         {ctyp =
            <:ctyp<
-             MLast.loc -> list MLast.type_decl -> MLast.str_item >>;
-         expr = Obj.repr (fun loc tdl -> MLast.StTyp loc tdl);
+             MLast.loc -> bool -> list MLast.type_decl -> MLast.str_item >>;
+         expr = Obj.repr (fun loc flg tdl -> MLast.StTyp loc flg tdl);
          patt = no_patt loc});
      ("MLast.StVal",
       fun loc ->

--- a/etc/pr_o.ml
+++ b/etc/pr_o.ml
@@ -1560,8 +1560,8 @@ EXTEND_PRINTER
           sig_module_or_module_type "module type" False '=' pc (m, mt)
       | <:str_item:< open $i$ >> ->
           pprintf pc "open %p" mod_ident (loc, i)
-      | <:str_item:< type $list:tdl$ >> ->
-          pprintf pc "type %p"
+      | <:str_item:< type $flag:nonrf$ $list:tdl$ >> ->
+          pprintf pc "type%s %p" (if nonrf then " nonrec" else "")
             (vlist2 type_decl (and_before type_decl)) tdl
       | <:str_item:< value $flag:rf$ $list:pel$ >> ->
           horiz_vertic

--- a/etc/pr_r.ml
+++ b/etc/pr_r.ml
@@ -1654,8 +1654,9 @@ EXTEND_PRINTER
           sig_module_or_module_type "module type" '=' pc (m, mt)
       | <:str_item:< open $i$ >> ->
           pprintf pc "open %p" mod_ident (loc, i)
-      | <:str_item< type $list:tdl$ >> ->
-          pprintf pc "type %p" (vlist2 type_decl (and_before type_decl)) tdl
+      | <:str_item< type $flag:nonrf$ $list:tdl$ >> ->
+          pprintf pc "type%s %p" (if nonrf then " nonrec" else "")
+            (vlist2 type_decl (and_before type_decl)) tdl
       | <:str_item< value $flag:rf$ $list:pel$ >> ->
           horiz_vertic
             (fun () ->

--- a/lib/versdep.ml
+++ b/lib/versdep.ml
@@ -1120,7 +1120,7 @@ value ocaml_pstr_recmodule =
   END
 ;
 
-value ocaml_pstr_type stl =
+value ocaml_pstr_type is_nonrec stl =
   IFDEF OCAML_VERSION < OCAML_4_00 THEN Pstr_type stl
   ELSIFDEF OCAML_VERSION < OCAML_4_02_0 THEN
     let stl = List.map (fun (s, t) → (mknoloc s, t)) stl in
@@ -1128,7 +1128,8 @@ value ocaml_pstr_type stl =
   ELSIFDEF OCAML_VERSION < OCAML_4_03_0 THEN
     let stl = List.map (fun (s, t) -> t) stl in Pstr_type stl
   ELSE
-    let stl = List.map (fun (s, t) -> t) stl in Pstr_type Recursive stl
+    let stl = List.map (fun (s, t) -> t) stl in
+    Pstr_type (if is_nonrec then Nonrecursive else Recursive) stl
   END
 ;
 

--- a/main/ast2pt.ml
+++ b/main/ast2pt.ml
@@ -1346,8 +1346,8 @@ and str_item s l =
       [mkstr loc
          (ocaml_pstr_open (mkloc loc) (long_id_of_string_list loc (uv id))) ::
        l]
-  | StTyp loc tdl →
-      [mkstr loc (ocaml_pstr_type (List.map mktype_decl (uv tdl))) :: l]
+  | StTyp loc flg tdl →
+      [mkstr loc (ocaml_pstr_type (uv flg) (List.map mktype_decl (uv tdl))) :: l]
   | StUse loc fn sl →
       Ploc.call_with glob_fname (uv fn)
         (fun () → List.fold_right (fun (si, _) → str_item si) (uv sl) l) ()

--- a/main/mLast.mli
+++ b/main/mLast.mli
@@ -180,7 +180,7 @@ and str_item =
   | StMod of loc and V bool and V (list (V string * module_expr))
   | StMty of loc and V string and module_type
   | StOpn of loc and V (list string)
-  | StTyp of loc and V (list type_decl)
+  | StTyp of loc and V bool and V (list type_decl)
   | StUse of loc and V string and V (list (str_item * loc))
   | StVal of loc and V bool and V (list (patt * expr))
   | StXtr of loc and string and option (V str_item) ]

--- a/main/reloc.ml
+++ b/main/reloc.ml
@@ -547,9 +547,9 @@ and str_item floc sh =
     | StOpn loc x1 →
         let loc = floc loc in
         StOpn loc x1
-    | StTyp loc x1 →
+    | StTyp loc flg x1 →
         let loc = floc loc in
-        StTyp loc (vala_map (List.map (type_decl floc sh)) x1)
+        StTyp loc flg (vala_map (List.map (type_decl floc sh)) x1)
     | StUse loc x1 x2 →
         let loc = floc loc in
         StUse loc x1

--- a/meta/pa_r.ml
+++ b/meta/pa_r.ml
@@ -170,10 +170,10 @@ EXTEND
           <:str_item< module $_flag:r$ $_list:l$ >>
       | "module"; "type"; i = V ident ""; mt = mod_type_fun_binding →
           <:str_item< module type $_:i$ = $mt$ >>
-      | "open"; i = V mod_ident "list" "" → <:str_item< open $_:i$ >>
-      | "type"; tdl = V (LIST1 type_decl SEP "and") →
-          <:str_item< type $_list:tdl$ >>
-      | "value"; r = V (FLAG "rec"); l = V (LIST1 let_binding SEP "and") →
+      | "open"; i = V mod_ident "list" "" -> <:str_item< open $_:i$ >>
+      | "type"; nrfl = V (FLAG "nonrec"); tdl = V (LIST1 type_decl SEP "and") →
+          <:str_item< type $_flag:nrfl$ $_list:tdl$ >>
+      | "value"; r = V (FLAG "rec"); l = V (LIST1 let_binding SEP "and") ->
           <:str_item< value $_flag:r$ $_list:l$ >>
       | "#"; n = V LIDENT "lid" ""; dp = V (OPT expr) →
           <:str_item< # $_lid:n$ $_opt:dp$ >>

--- a/meta/q_MLast.ml
+++ b/meta/q_MLast.ml
@@ -322,8 +322,9 @@ EXTEND
       | "module"; "type"; i = SV ident ""; mt = mod_type_fun_binding →
           Qast.Node "StMty" [Qast.Loc; i; mt]
       | "open"; i = SV mod_ident "list" "" → Qast.Node "StOpn" [Qast.Loc; i]
-      | "type"; tdl = SV (LIST1 type_decl SEP "and") →
-          Qast.Node "StTyp" [Qast.Loc; tdl]
+      | "type"; nrfl = SV (FLAG "nonrec");
+        tdl = SV (LIST1 type_decl SEP "and") →
+          Qast.Node "StTyp" [Qast.Loc; nrfl; tdl]
       | "value"; r = SV (FLAG "rec"); l = SV (LIST1 let_binding SEP "and") →
           Qast.Node "StVal" [Qast.Loc; r; l]
       | "#"; n = SV LIDENT; dp = SV (OPT expr) →

--- a/meta/q_ast.ml
+++ b/meta/q_ast.ml
@@ -381,7 +381,8 @@ module Meta_make (C : MetaSig) =
                lsme]
       | StMty _ s mt → C.node "StMty" [C.vala C.string s; module_type mt]
       | StOpn _ ls → C.node "StOpn" [C.vala (C.list C.string) ls]
-      | StTyp _ ltd → C.node "StTyp" [C.vala (C.list type_decl) ltd]
+      | StTyp _ b ltd →
+          C.node "StTyp" [C.vala C.bool b; C.vala (C.list type_decl) ltd]
       | StUse _ s lsil →
           C.node "StUse"
             [C.vala C.string s;

--- a/ocaml_src/lib/versdep/1.06.ml
+++ b/ocaml_src/lib/versdep/1.06.ml
@@ -352,7 +352,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos = None;;
 

--- a/ocaml_src/lib/versdep/1.07.ml
+++ b/ocaml_src/lib/versdep/1.07.ml
@@ -352,7 +352,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos = None;;
 

--- a/ocaml_src/lib/versdep/2.00.ml
+++ b/ocaml_src/lib/versdep/2.00.ml
@@ -340,7 +340,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/2.01.ml
+++ b/ocaml_src/lib/versdep/2.01.ml
@@ -340,7 +340,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/2.02.ml
+++ b/ocaml_src/lib/versdep/2.02.ml
@@ -340,7 +340,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/2.03.ml
+++ b/ocaml_src/lib/versdep/2.03.ml
@@ -341,7 +341,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/2.04.ml
+++ b/ocaml_src/lib/versdep/2.04.ml
@@ -341,7 +341,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/2.99.ml
+++ b/ocaml_src/lib/versdep/2.99.ml
@@ -373,7 +373,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.00.ml
+++ b/ocaml_src/lib/versdep/3.00.ml
@@ -375,7 +375,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.01.ml
+++ b/ocaml_src/lib/versdep/3.01.ml
@@ -342,7 +342,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.02.ml
+++ b/ocaml_src/lib/versdep/3.02.ml
@@ -355,7 +355,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.03.ml
+++ b/ocaml_src/lib/versdep/3.03.ml
@@ -348,7 +348,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.04.ml
+++ b/ocaml_src/lib/versdep/3.04.ml
@@ -348,7 +348,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.05.ml
+++ b/ocaml_src/lib/versdep/3.05.ml
@@ -348,7 +348,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.06.ml
+++ b/ocaml_src/lib/versdep/3.06.ml
@@ -348,7 +348,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = None;;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.07.ml
+++ b/ocaml_src/lib/versdep/3.07.ml
@@ -363,7 +363,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.08.0.ml
+++ b/ocaml_src/lib/versdep/3.08.0.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.08.1.ml
+++ b/ocaml_src/lib/versdep/3.08.1.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.08.2.ml
+++ b/ocaml_src/lib/versdep/3.08.2.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.08.3.ml
+++ b/ocaml_src/lib/versdep/3.08.3.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.08.4.ml
+++ b/ocaml_src/lib/versdep/3.08.4.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.09.0.ml
+++ b/ocaml_src/lib/versdep/3.09.0.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.09.1.ml
+++ b/ocaml_src/lib/versdep/3.09.1.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.09.2.ml
+++ b/ocaml_src/lib/versdep/3.09.2.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.09.3.ml
+++ b/ocaml_src/lib/versdep/3.09.3.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.09.4.ml
+++ b/ocaml_src/lib/versdep/3.09.4.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.10.0.ml
+++ b/ocaml_src/lib/versdep/3.10.0.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.10.1.ml
+++ b/ocaml_src/lib/versdep/3.10.1.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.10.2.ml
+++ b/ocaml_src/lib/versdep/3.10.2.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.10.3.ml
+++ b/ocaml_src/lib/versdep/3.10.3.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.10.ml
+++ b/ocaml_src/lib/versdep/3.10.ml
@@ -366,7 +366,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.11.0.ml
+++ b/ocaml_src/lib/versdep/3.11.0.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.11.1.ml
+++ b/ocaml_src/lib/versdep/3.11.1.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.11.2.ml
+++ b/ocaml_src/lib/versdep/3.11.2.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.11.3.ml
+++ b/ocaml_src/lib/versdep/3.11.3.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.11.ml
+++ b/ocaml_src/lib/versdep/3.11.ml
@@ -364,7 +364,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.12.0.ml
+++ b/ocaml_src/lib/versdep/3.12.0.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.12.1.ml
+++ b/ocaml_src/lib/versdep/3.12.1.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.12.2.ml
+++ b/ocaml_src/lib/versdep/3.12.2.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/3.13.0-gadt.ml
+++ b/ocaml_src/lib/versdep/3.13.0-gadt.ml
@@ -364,7 +364,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/4.00.0.ml
+++ b/ocaml_src/lib/versdep/4.00.0.ml
@@ -388,7 +388,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> mknoloc s, t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.00.1.ml
+++ b/ocaml_src/lib/versdep/4.00.1.ml
@@ -388,7 +388,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> mknoloc s, t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.00.2.ml
+++ b/ocaml_src/lib/versdep/4.00.2.ml
@@ -388,7 +388,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> mknoloc s, t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.01.0.ml
+++ b/ocaml_src/lib/versdep/4.01.0.ml
@@ -388,7 +388,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> mknoloc s, t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.01.1.ml
+++ b/ocaml_src/lib/versdep/4.01.1.ml
@@ -388,7 +388,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> mknoloc s, t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.02.0.ml
+++ b/ocaml_src/lib/versdep/4.02.0.ml
@@ -506,7 +506,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.02.1.ml
+++ b/ocaml_src/lib/versdep/4.02.1.ml
@@ -506,7 +506,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.02.2.ml
+++ b/ocaml_src/lib/versdep/4.02.2.ml
@@ -506,7 +506,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.02.3.ml
+++ b/ocaml_src/lib/versdep/4.02.3.ml
@@ -506,7 +506,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.02.4.ml
+++ b/ocaml_src/lib/versdep/4.02.4.ml
@@ -506,7 +506,7 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> t) stl in Pstr_type stl
 ;;
 

--- a/ocaml_src/lib/versdep/4.03.0.ml
+++ b/ocaml_src/lib/versdep/4.03.0.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.03.1.ml
+++ b/ocaml_src/lib/versdep/4.03.1.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.04.0.ml
+++ b/ocaml_src/lib/versdep/4.04.0.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.04.1.ml
+++ b/ocaml_src/lib/versdep/4.04.1.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.04.2.ml
+++ b/ocaml_src/lib/versdep/4.04.2.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.04.3.ml
+++ b/ocaml_src/lib/versdep/4.04.3.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.05.0.ml
+++ b/ocaml_src/lib/versdep/4.05.0.ml
@@ -508,9 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type nonrec_flg stl =
+let ocaml_pstr_type is_nonrec stl =
   let stl = List.map (fun (s, t) -> t) stl in
-  Pstr_type ((if nonrec_flg then Nonrecursive else Recursive), stl)
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.05.0.ml
+++ b/ocaml_src/lib/versdep/4.05.0.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type nonrec_flg stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if nonrec_flg then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.05.1.ml
+++ b/ocaml_src/lib/versdep/4.05.1.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.06.0.ml
+++ b/ocaml_src/lib/versdep/4.06.0.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.06.1.ml
+++ b/ocaml_src/lib/versdep/4.06.1.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.06.2.ml
+++ b/ocaml_src/lib/versdep/4.06.2.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.07.0.ml
+++ b/ocaml_src/lib/versdep/4.07.0.ml
@@ -508,8 +508,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/4.08.0.ml
+++ b/ocaml_src/lib/versdep/4.08.0.ml
@@ -514,8 +514,9 @@ let ocaml_pstr_recmodule =
   Some f
 ;;
 
-let ocaml_pstr_type stl =
-  let stl = List.map (fun (s, t) -> t) stl in Pstr_type (Recursive, stl)
+let ocaml_pstr_type is_nonrec stl =
+  let stl = List.map (fun (s, t) -> t) stl in
+  Pstr_type ((if is_nonrec then Nonrecursive else Recursive), stl)
 ;;
 
 let ocaml_class_infos =

--- a/ocaml_src/lib/versdep/jocaml/3.12.0.ml
+++ b/ocaml_src/lib/versdep/jocaml/3.12.0.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/jocaml/3.12.1.ml
+++ b/ocaml_src/lib/versdep/jocaml/3.12.1.ml
@@ -365,7 +365,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/lib/versdep/jocaml/3.13.0.ml
+++ b/ocaml_src/lib/versdep/jocaml/3.13.0.ml
@@ -367,7 +367,7 @@ let ocaml_pstr_primitive s vd = Pstr_primitive (mknoloc s, vd);;
 
 let ocaml_pstr_recmodule = Some (fun nel -> Pstr_recmodule nel);;
 
-let ocaml_pstr_type stl = Pstr_type stl;;
+let ocaml_pstr_type is_nonrec stl = Pstr_type stl;;
 
 let ocaml_class_infos =
   Some

--- a/ocaml_src/main/ast2pt.ml
+++ b/ocaml_src/main/ast2pt.ml
@@ -1534,8 +1534,9 @@ and str_item s l =
       mkstr loc
         (ocaml_pstr_open (mkloc loc) (long_id_of_string_list loc (uv id))) ::
       l
-  | StTyp (loc, tdl) ->
-      mkstr loc (ocaml_pstr_type (List.map mktype_decl (uv tdl))) :: l
+  | StTyp (loc, flg, tdl) ->
+      mkstr loc (ocaml_pstr_type (uv flg) (List.map mktype_decl (uv tdl))) ::
+      l
   | StUse (loc, fn, sl) ->
       Ploc.call_with glob_fname (uv fn)
         (fun () -> List.fold_right (fun (si, _) -> str_item si) (uv sl) l) ()

--- a/ocaml_src/main/mLast.mli
+++ b/ocaml_src/main/mLast.mli
@@ -175,7 +175,7 @@ and str_item =
   | StMod of loc * bool * (string * module_expr) list
   | StMty of loc * string * module_type
   | StOpn of loc * string list
-  | StTyp of loc * type_decl list
+  | StTyp of loc * bool * type_decl list
   | StUse of loc * string * (str_item * loc) list
   | StVal of loc * bool * (patt * expr) list
   | StXtr of loc * string * str_item option

--- a/ocaml_src/main/reloc.ml
+++ b/ocaml_src/main/reloc.ml
@@ -430,9 +430,9 @@ and str_item floc sh =
     | StMty (loc, x1, x2) ->
         let loc = floc loc in StMty (loc, x1, module_type floc sh x2)
     | StOpn (loc, x1) -> let loc = floc loc in StOpn (loc, x1)
-    | StTyp (loc, x1) ->
+    | StTyp (loc, flg, x1) ->
         let loc = floc loc in
-        StTyp (loc, vala_map (List.map (type_decl floc sh)) x1)
+        StTyp (loc, flg, vala_map (List.map (type_decl floc sh)) x1)
     | StUse (loc, x1, x2) ->
         let loc = floc loc in
         StUse

--- a/ocaml_src/meta/pa_r.ml
+++ b/ocaml_src/meta/pa_r.ml
@@ -419,12 +419,14 @@ Grammar.safe_extend
               (MLast.StVal (loc, r, l) : 'str_item)));
         Grammar.production
           (Grammar.r_next
-             (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "type")))
+             (Grammar.r_next
+                (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "type")))
+                (Grammar.s_flag (Grammar.s_token ("", "nonrec"))))
              (Grammar.s_list1sep
                 (Grammar.s_nterm (type_decl : 'type_decl Grammar.Entry.e))
                 (Grammar.s_token ("", "and")) false),
-           (fun (tdl : 'type_decl list) _ (loc : Ploc.t) ->
-              (MLast.StTyp (loc, tdl) : 'str_item)));
+           (fun (tdl : 'type_decl list) (nrfl : bool) _ (loc : Ploc.t) ->
+              (MLast.StTyp (loc, nrfl, tdl) : 'str_item)));
         Grammar.production
           (Grammar.r_next
              (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "open")))

--- a/ocaml_src/meta/q_MLast.ml
+++ b/ocaml_src/meta/q_MLast.ml
@@ -675,18 +675,18 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("STRING", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__18)));
+                             (Qast.VaVal (Qast.Str a) : 'e__19)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_str")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_str", loc, a) : 'e__18)));
+                             (Qast.VaAnt ("_str", loc, a) : 'e__19)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "str")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("str", loc, a)) :
-                              'e__18)))])))
+                              'e__19)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -700,21 +700,21 @@ Grammar.safe_extend
                                          'str_item Grammar.Entry.e)),
                                    (fun (si : 'str_item) (loc : Ploc.t) ->
                                       (Qast.Tuple [si; Qast.Loc] :
-                                       'e__19)))])),
-                       (fun (a : 'e__19 list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__20)));
+                                       'e__20)))])),
+                       (fun (a : 'e__20 list) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.List a) : 'e__21)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__20)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__21)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__20)))])),
-           (fun (sil : 'e__20) (s : 'e__18) _ (loc : Ploc.t) ->
+                           'e__21)))])),
+           (fun (sil : 'e__21) (s : 'e__19) _ (loc : Ploc.t) ->
               (Qast.Node ("StUse", [Qast.Loc; s; sil]) : 'str_item)));
         Grammar.production
           (Grammar.r_next
@@ -726,29 +726,29 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("LIDENT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__16)));
+                             (Qast.VaVal (Qast.Str a) : 'e__17)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_", loc, a) : 'e__16)));
+                             (Qast.VaAnt ("_", loc, a) : 'e__17)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                              'e__16)));
+                              'e__17)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_lid")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_lid", loc, a) : 'e__16)));
+                             (Qast.VaAnt ("_lid", loc, a) : 'e__17)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "lid")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                              'e__16)))])))
+                              'e__17)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -756,19 +756,19 @@ Grammar.safe_extend
                          (Grammar.s_opt
                             (Grammar.s_nterm (expr : 'expr Grammar.Entry.e))),
                        (fun (a : 'expr option) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Option a) : 'e__17)));
+                          (Qast.VaVal (Qast.Option a) : 'e__18)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_opt")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_opt", loc, a) : 'e__17)));
+                          (Qast.VaAnt ("_opt", loc, a) : 'e__18)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "opt")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                           'e__17)))])),
-           (fun (dp : 'e__17) (n : 'e__16) _ (loc : Ploc.t) ->
+                           'e__18)))])),
+           (fun (dp : 'e__18) (n : 'e__17) _ (loc : Ploc.t) ->
               (Qast.Node ("StDir", [Qast.Loc; n; dp]) : 'str_item)));
         Grammar.production
           (Grammar.r_next
@@ -781,29 +781,29 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_flag (Grammar.s_token ("", "rec"))),
                           (fun (a : bool) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Bool a) : 'e__14)));
+                             (Qast.VaVal (Qast.Bool a) : 'e__15)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__14)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__15)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__14)));
+                              'e__15)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_flag")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_flag", loc, a) : 'e__14)));
+                             (Qast.VaAnt ("_flag", loc, a) : 'e__15)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "flag")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                              'e__14)))])))
+                              'e__15)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -813,23 +813,53 @@ Grammar.safe_extend
                                (let_binding : 'let_binding Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'let_binding list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__15)));
+                          (Qast.VaVal (Qast.List a) : 'e__16)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__15)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__16)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__15)))])),
-           (fun (l : 'e__15) (r : 'e__14) _ (loc : Ploc.t) ->
+                           'e__16)))])),
+           (fun (l : 'e__16) (r : 'e__15) _ (loc : Ploc.t) ->
               (Qast.Node ("StVal", [Qast.Loc; r; l]) : 'str_item)));
         Grammar.production
           (Grammar.r_next
-             (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "type")))
+             (Grammar.r_next
+                (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "type")))
+                (Grammar.s_facto
+                   (Grammar.s_rules
+                      [Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_flag (Grammar.s_token ("", "nonrec"))),
+                          (fun (a : bool) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.Bool a) : 'e__13)));
+                       Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("ANTIQUOT", "_opt")),
+                          (fun (a : string) (loc : Ploc.t) ->
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__13)));
+                       Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("ANTIQUOT", "opt")),
+                          (fun (a : string) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
+                              'e__13)));
+                       Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("ANTIQUOT", "_flag")),
+                          (fun (a : string) (loc : Ploc.t) ->
+                             (Qast.VaAnt ("_flag", loc, a) : 'e__13)));
+                       Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("ANTIQUOT", "flag")),
+                          (fun (a : string) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
+                              'e__13)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -839,20 +869,20 @@ Grammar.safe_extend
                                (type_decl : 'type_decl Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'type_decl list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__13)));
+                          (Qast.VaVal (Qast.List a) : 'e__14)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__13)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__14)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__13)))])),
-           (fun (tdl : 'e__13) _ (loc : Ploc.t) ->
-              (Qast.Node ("StTyp", [Qast.Loc; tdl]) : 'str_item)));
+                           'e__14)))])),
+           (fun (tdl : 'e__14) (nrfl : 'e__13) _ (loc : Ploc.t) ->
+              (Qast.Node ("StTyp", [Qast.Loc; nrfl; tdl]) : 'str_item)));
         Grammar.production
           (Grammar.r_next
              (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "open")))
@@ -1059,7 +1089,7 @@ Grammar.safe_extend
               (let (_, c, tl, _) =
                  match ctl with
                    Qast.Tuple [xx1; xx2; xx3; xx4] -> xx1, xx2, xx3, xx4
-                 | _ -> raise (Match_failure ("q_MLast.ml", 313, 20))
+                 | _ -> raise (Match_failure ("q_MLast.ml", 313, 19))
                in
                Qast.Node ("StExc", [Qast.Loc; c; tl; b]) :
                'str_item)));
@@ -1114,29 +1144,29 @@ Grammar.safe_extend
                          (Grammar.s_nterm
                             (mod_ident : 'mod_ident Grammar.Entry.e)),
                        (fun (a : 'mod_ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__21)));
+                          (Qast.VaVal a : 'e__22)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__21)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__22)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__21)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__22)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__21)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__22)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__21)))])),
-           (fun (a : 'e__21) _ (loc : Ploc.t) -> (a : 'rebind_exn)))]];
+                           'e__22)))])),
+           (fun (a : 'e__22) _ (loc : Ploc.t) -> (a : 'rebind_exn)))]];
     Grammar.extension (mod_binding : 'mod_binding Grammar.Entry.e) None
       [None, None,
        [Grammar.production
@@ -1148,32 +1178,32 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("UIDENT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__22)));
+                             (Qast.VaVal (Qast.Str a) : 'e__23)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_", loc, a) : 'e__22)));
+                             (Qast.VaAnt ("_", loc, a) : 'e__23)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                              'e__22)));
+                              'e__23)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_uid")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_uid", loc, a) : 'e__22)));
+                             (Qast.VaAnt ("_uid", loc, a) : 'e__23)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "uid")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                              'e__22)))])))
+                              'e__23)))])))
              (Grammar.s_nterm
                 (mod_fun_binding : 'mod_fun_binding Grammar.Entry.e)),
-           (fun (me : 'mod_fun_binding) (i : 'e__22) (loc : Ploc.t) ->
+           (fun (me : 'mod_fun_binding) (i : 'e__23) (loc : Ploc.t) ->
               (Qast.Tuple [i; me] : 'mod_binding)))]];
     Grammar.extension (mod_fun_binding : 'mod_fun_binding Grammar.Entry.e)
       None
@@ -1195,63 +1225,6 @@ Grammar.safe_extend
              (Grammar.s_nterm (module_expr : 'module_expr Grammar.Entry.e)),
            (fun (me : 'module_expr) _ (mt : 'module_type) _ (loc : Ploc.t) ->
               (Qast.Node ("MeTyc", [Qast.Loc; me; mt]) : 'mod_fun_binding)));
-        Grammar.production
-          (Grammar.r_next
-             (Grammar.r_next
-                (Grammar.r_next
-                   (Grammar.r_next
-                      (Grammar.r_next
-                         (Grammar.r_next Grammar.r_stop
-                            (Grammar.s_token ("", "(")))
-                         (Grammar.s_facto
-                            (Grammar.s_rules
-                               [Grammar.production
-                                  (Grammar.r_next Grammar.r_stop
-                                     (Grammar.s_token ("UIDENT", "")),
-                                   (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.Str a) : 'e__23)));
-                                Grammar.production
-                                  (Grammar.r_next Grammar.r_stop
-                                     (Grammar.s_token ("ANTIQUOT", "_")),
-                                   (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaAnt ("_", loc, a) : 'e__23)));
-                                Grammar.production
-                                  (Grammar.r_next Grammar.r_stop
-                                     (Grammar.s_token ("ANTIQUOT", "")),
-                                   (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                       'e__23)));
-                                Grammar.production
-                                  (Grammar.r_next Grammar.r_stop
-                                     (Grammar.s_token ("ANTIQUOT", "_uid")),
-                                   (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaAnt ("_uid", loc, a) :
-                                       'e__23)));
-                                Grammar.production
-                                  (Grammar.r_next Grammar.r_stop
-                                     (Grammar.s_token ("ANTIQUOT", "uid")),
-                                   (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaVal
-                                         (Qast.VaAnt ("uid", loc, a)) :
-                                       'e__23)))])))
-                      (Grammar.s_token ("", ":")))
-                   (Grammar.s_nterm
-                      (module_type : 'module_type Grammar.Entry.e)))
-                (Grammar.s_token ("", ")")))
-             Grammar.s_self,
-           (fun (mb : 'mod_fun_binding) _ (mt : 'module_type) _ (m : 'e__23) _
-                (loc : Ploc.t) ->
-              (Qast.Node ("MeFun", [Qast.Loc; m; mt; mb]) :
-               'mod_fun_binding)))]];
-    Grammar.extension
-      (mod_type_fun_binding : 'mod_type_fun_binding Grammar.Entry.e) None
-      [None, None,
-       [Grammar.production
-          (Grammar.r_next
-             (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "=")))
-             (Grammar.s_nterm (module_type : 'module_type Grammar.Entry.e)),
-           (fun (mt : 'module_type) _ (loc : Ploc.t) ->
-              (mt : 'mod_type_fun_binding)));
         Grammar.production
           (Grammar.r_next
              (Grammar.r_next
@@ -1296,8 +1269,65 @@ Grammar.safe_extend
                       (module_type : 'module_type Grammar.Entry.e)))
                 (Grammar.s_token ("", ")")))
              Grammar.s_self,
+           (fun (mb : 'mod_fun_binding) _ (mt : 'module_type) _ (m : 'e__24) _
+                (loc : Ploc.t) ->
+              (Qast.Node ("MeFun", [Qast.Loc; m; mt; mb]) :
+               'mod_fun_binding)))]];
+    Grammar.extension
+      (mod_type_fun_binding : 'mod_type_fun_binding Grammar.Entry.e) None
+      [None, None,
+       [Grammar.production
+          (Grammar.r_next
+             (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "=")))
+             (Grammar.s_nterm (module_type : 'module_type Grammar.Entry.e)),
+           (fun (mt : 'module_type) _ (loc : Ploc.t) ->
+              (mt : 'mod_type_fun_binding)));
+        Grammar.production
+          (Grammar.r_next
+             (Grammar.r_next
+                (Grammar.r_next
+                   (Grammar.r_next
+                      (Grammar.r_next
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("", "(")))
+                         (Grammar.s_facto
+                            (Grammar.s_rules
+                               [Grammar.production
+                                  (Grammar.r_next Grammar.r_stop
+                                     (Grammar.s_token ("UIDENT", "")),
+                                   (fun (a : string) (loc : Ploc.t) ->
+                                      (Qast.VaVal (Qast.Str a) : 'e__25)));
+                                Grammar.production
+                                  (Grammar.r_next Grammar.r_stop
+                                     (Grammar.s_token ("ANTIQUOT", "_")),
+                                   (fun (a : string) (loc : Ploc.t) ->
+                                      (Qast.VaAnt ("_", loc, a) : 'e__25)));
+                                Grammar.production
+                                  (Grammar.r_next Grammar.r_stop
+                                     (Grammar.s_token ("ANTIQUOT", "")),
+                                   (fun (a : string) (loc : Ploc.t) ->
+                                      (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
+                                       'e__25)));
+                                Grammar.production
+                                  (Grammar.r_next Grammar.r_stop
+                                     (Grammar.s_token ("ANTIQUOT", "_uid")),
+                                   (fun (a : string) (loc : Ploc.t) ->
+                                      (Qast.VaAnt ("_uid", loc, a) :
+                                       'e__25)));
+                                Grammar.production
+                                  (Grammar.r_next Grammar.r_stop
+                                     (Grammar.s_token ("ANTIQUOT", "uid")),
+                                   (fun (a : string) (loc : Ploc.t) ->
+                                      (Qast.VaVal
+                                         (Qast.VaAnt ("uid", loc, a)) :
+                                       'e__25)))])))
+                      (Grammar.s_token ("", ":")))
+                   (Grammar.s_nterm
+                      (module_type : 'module_type Grammar.Entry.e)))
+                (Grammar.s_token ("", ")")))
+             Grammar.s_self,
            (fun (mt2 : 'mod_type_fun_binding) _ (mt1 : 'module_type) _
-                (m : 'e__24) _ (loc : Ploc.t) ->
+                (m : 'e__25) _ (loc : Ploc.t) ->
               (Qast.Node ("MtFun", [Qast.Loc; m; mt1; mt2]) :
                'mod_type_fun_binding)))]];
     Grammar.extension (module_type : 'module_type Grammar.Entry.e) None
@@ -1319,40 +1349,40 @@ Grammar.safe_extend
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("UIDENT", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
-                                         (Qast.VaVal (Qast.Str a) : 'e__25)));
+                                         (Qast.VaVal (Qast.Str a) : 'e__26)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "_")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_", loc, a) :
-                                          'e__25)));
+                                          'e__26)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("", loc, a)) :
-                                          'e__25)));
+                                          'e__26)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token
                                            ("ANTIQUOT", "_uid")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_uid", loc, a) :
-                                          'e__25)));
+                                          'e__26)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "uid")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("uid", loc, a)) :
-                                          'e__25)))])))
+                                          'e__26)))])))
                          (Grammar.s_token ("", ":")))
                       Grammar.s_self)
                    (Grammar.s_token ("", ")")))
                 (Grammar.s_token ("", "->")))
              Grammar.s_self,
-           (fun (mt : 'module_type) _ _ (t : 'module_type) _ (i : 'e__25) _ _
+           (fun (mt : 'module_type) _ _ (t : 'module_type) _ (i : 'e__26) _ _
                 (loc : Ploc.t) ->
               (Qast.Node ("MtFun", [Qast.Loc; i; t; mt]) : 'module_type)))];
        None, None,
@@ -1369,19 +1399,19 @@ Grammar.safe_extend
                                (with_constr : 'with_constr Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'with_constr list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__26)));
+                          (Qast.VaVal (Qast.List a) : 'e__27)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__26)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__27)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__26)))])),
-           (fun (wcl : 'e__26) _ (mt : 'module_type) (loc : Ploc.t) ->
+                           'e__27)))])),
+           (fun (wcl : 'e__27) _ (mt : 'module_type) (loc : Ploc.t) ->
               (Qast.Node ("MtWit", [Qast.Loc; mt; wcl]) : 'module_type)))];
        None, None,
        [Grammar.production
@@ -1438,7 +1468,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (ident : 'ident Grammar.Entry.e)),
                        (fun (a : 'ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__29)));
+                          (Qast.VaVal a : 'e__30)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "_")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaAnt ("_", loc, a) : 'e__30)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
+                           'e__30)))])),
+           (fun (i : 'e__30) _ (loc : Ploc.t) ->
+              (Qast.Node ("MtQuo", [Qast.Loc; i]) : 'module_type)));
+        Grammar.production
+          (Grammar.r_next Grammar.r_stop
+             (Grammar.s_facto
+                (Grammar.s_rules
+                   [Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("LIDENT", "")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Str a) : 'e__29)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
@@ -1448,17 +1500,27 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__29)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "_lid")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__29)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "lid")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
                            'e__29)))])),
-           (fun (i : 'e__29) _ (loc : Ploc.t) ->
-              (Qast.Node ("MtQuo", [Qast.Loc; i]) : 'module_type)));
+           (fun (i : 'e__29) (loc : Ploc.t) ->
+              (Qast.Node ("MtLid", [Qast.Loc; i]) : 'module_type)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
                       (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("LIDENT", "")),
+                         (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.Str a) : 'e__28)));
                     Grammar.production
@@ -1473,48 +1535,16 @@ Grammar.safe_extend
                           (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__28)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "_lid")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__28)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "lid")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__28)))])),
-           (fun (i : 'e__28) (loc : Ploc.t) ->
-              (Qast.Node ("MtLid", [Qast.Loc; i]) : 'module_type)));
-        Grammar.production
-          (Grammar.r_next Grammar.r_stop
-             (Grammar.s_facto
-                (Grammar.s_rules
-                   [Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("UIDENT", "")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__27)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "_")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__27)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__27)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_uid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__27)));
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__28)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "uid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__27)))])),
-           (fun (i : 'e__27) (loc : Ploc.t) ->
+                           'e__28)))])),
+           (fun (i : 'e__28) (loc : Ploc.t) ->
               (Qast.Node ("MtUid", [Qast.Loc; i]) : 'module_type)))]];
     Grammar.extension (signature : 'signature Grammar.Entry.e) None
       [None, None,
@@ -1534,21 +1564,21 @@ Grammar.safe_extend
                                             'sig_item Grammar.Entry.e)))
                                      (Grammar.s_token ("", ";")),
                                    (fun _ (s : 'sig_item) (loc : Ploc.t) ->
-                                      (s : 'e__30)))])),
-                       (fun (a : 'e__30 list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__31)));
+                                      (s : 'e__31)))])),
+                       (fun (a : 'e__31 list) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.List a) : 'e__32)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__31)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__32)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__31)))])),
-           (fun (st : 'e__31) (loc : Ploc.t) -> (st : 'signature)))]];
+                           'e__32)))])),
+           (fun (st : 'e__32) (loc : Ploc.t) -> (st : 'signature)))]];
     Grammar.extension (sig_item : 'sig_item Grammar.Entry.e) None
       [Some "top", None,
        [Grammar.production
@@ -1561,18 +1591,18 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("STRING", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__44)));
+                             (Qast.VaVal (Qast.Str a) : 'e__45)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_str")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_str", loc, a) : 'e__44)));
+                             (Qast.VaAnt ("_str", loc, a) : 'e__45)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "str")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("str", loc, a)) :
-                              'e__44)))])))
+                              'e__45)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -1586,21 +1616,21 @@ Grammar.safe_extend
                                          'sig_item Grammar.Entry.e)),
                                    (fun (si : 'sig_item) (loc : Ploc.t) ->
                                       (Qast.Tuple [si; Qast.Loc] :
-                                       'e__45)))])),
-                       (fun (a : 'e__45 list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__46)));
+                                       'e__46)))])),
+                       (fun (a : 'e__46 list) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.List a) : 'e__47)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__46)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__47)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__46)))])),
-           (fun (sil : 'e__46) (s : 'e__44) _ (loc : Ploc.t) ->
+                           'e__47)))])),
+           (fun (sil : 'e__47) (s : 'e__45) _ (loc : Ploc.t) ->
               (Qast.Node ("SgUse", [Qast.Loc; s; sil]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1612,29 +1642,29 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("LIDENT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__42)));
+                             (Qast.VaVal (Qast.Str a) : 'e__43)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_", loc, a) : 'e__42)));
+                             (Qast.VaAnt ("_", loc, a) : 'e__43)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                              'e__42)));
+                              'e__43)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_lid")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_lid", loc, a) : 'e__42)));
+                             (Qast.VaAnt ("_lid", loc, a) : 'e__43)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "lid")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                              'e__42)))])))
+                              'e__43)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -1642,19 +1672,19 @@ Grammar.safe_extend
                          (Grammar.s_opt
                             (Grammar.s_nterm (expr : 'expr Grammar.Entry.e))),
                        (fun (a : 'expr option) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Option a) : 'e__43)));
+                          (Qast.VaVal (Qast.Option a) : 'e__44)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_opt")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_opt", loc, a) : 'e__43)));
+                          (Qast.VaAnt ("_opt", loc, a) : 'e__44)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "opt")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                           'e__43)))])),
-           (fun (dp : 'e__43) (n : 'e__42) _ (loc : Ploc.t) ->
+                           'e__44)))])),
+           (fun (dp : 'e__44) (n : 'e__43) _ (loc : Ploc.t) ->
               (Qast.Node ("SgDir", [Qast.Loc; n; dp]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1668,32 +1698,32 @@ Grammar.safe_extend
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("LIDENT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Str a) : 'e__41)));
+                                (Qast.VaVal (Qast.Str a) : 'e__42)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__41)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__42)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__41)));
+                                 'e__42)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__41)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__42)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__41)))])))
+                                 'e__42)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (i : 'e__41) _ (loc : Ploc.t) ->
+           (fun (t : 'ctyp) _ (i : 'e__42) _ (loc : Ploc.t) ->
               (Qast.Node ("SgVal", [Qast.Loc; i; t]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1707,19 +1737,19 @@ Grammar.safe_extend
                                (type_decl : 'type_decl Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'type_decl list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__40)));
+                          (Qast.VaVal (Qast.List a) : 'e__41)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__40)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__41)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__40)))])),
-           (fun (tdl : 'e__40) _ (loc : Ploc.t) ->
+                           'e__41)))])),
+           (fun (tdl : 'e__41) _ (loc : Ploc.t) ->
               (Qast.Node ("SgTyp", [Qast.Loc; tdl]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1731,29 +1761,29 @@ Grammar.safe_extend
                          (Grammar.s_nterm
                             (mod_ident : 'mod_ident Grammar.Entry.e)),
                        (fun (a : 'mod_ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__39)));
+                          (Qast.VaVal a : 'e__40)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__39)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__40)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__39)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__40)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__39)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__40)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__39)))])),
-           (fun (i : 'e__39) _ (loc : Ploc.t) ->
+                           'e__40)))])),
+           (fun (i : 'e__40) _ (loc : Ploc.t) ->
               (Qast.Node ("SgOpn", [Qast.Loc; i]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1770,21 +1800,21 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (ident : 'ident Grammar.Entry.e)),
                              (fun (a : 'ident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__38)));
+                                (Qast.VaVal a : 'e__39)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__38)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__39)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__38)))])))
+                                 'e__39)))])))
                 (Grammar.s_token ("", "=")))
              (Grammar.s_nterm (module_type : 'module_type Grammar.Entry.e)),
-           (fun (mt : 'module_type) _ (i : 'e__38) _ _ (loc : Ploc.t) ->
+           (fun (mt : 'module_type) _ (i : 'e__39) _ _ (loc : Ploc.t) ->
               (Qast.Node ("SgMty", [Qast.Loc; i; mt]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1797,29 +1827,29 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_flag (Grammar.s_token ("", "rec"))),
                           (fun (a : bool) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Bool a) : 'e__36)));
+                             (Qast.VaVal (Qast.Bool a) : 'e__37)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__36)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__37)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__36)));
+                              'e__37)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_flag")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_flag", loc, a) : 'e__36)));
+                             (Qast.VaAnt ("_flag", loc, a) : 'e__37)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "flag")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                              'e__36)))])))
+                              'e__37)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -1830,19 +1860,19 @@ Grammar.safe_extend
                                 'mod_decl_binding Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'mod_decl_binding list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__37)));
+                          (Qast.VaVal (Qast.List a) : 'e__38)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__37)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__38)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__37)))])),
-           (fun (l : 'e__37) (rf : 'e__36) _ (loc : Ploc.t) ->
+                           'e__38)))])),
+           (fun (l : 'e__38) (rf : 'e__37) _ (loc : Ploc.t) ->
               (Qast.Node ("SgMod", [Qast.Loc; rf; l]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1864,31 +1894,31 @@ Grammar.safe_extend
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("LIDENT", "")),
                                    (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.Str a) : 'e__34)));
+                                      (Qast.VaVal (Qast.Str a) : 'e__35)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_")),
                                    (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaAnt ("_", loc, a) : 'e__34)));
+                                      (Qast.VaAnt ("_", loc, a) : 'e__35)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                       'e__34)));
+                                       'e__35)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_lid")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_lid", loc, a) :
-                                       'e__34)));
+                                       'e__35)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "lid")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("lid", loc, a)) :
-                                       'e__34)))])))
+                                       'e__35)))])))
                       (Grammar.s_token ("", ":")))
                    (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)))
                 (Grammar.s_token ("", "=")))
@@ -1900,19 +1930,19 @@ Grammar.safe_extend
                        (fun (a : string list) (loc : Ploc.t) ->
                           (Qast.VaVal
                              (Qast.List (List.map (fun a -> Qast.Str a) a)) :
-                           'e__35)));
+                           'e__36)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__35)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__36)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__35)))])),
-           (fun (pd : 'e__35) _ (t : 'ctyp) _ (i : 'e__34) _ (loc : Ploc.t) ->
+                           'e__36)))])),
+           (fun (pd : 'e__36) _ (t : 'ctyp) _ (i : 'e__35) _ (loc : Ploc.t) ->
               (Qast.Node ("SgExt", [Qast.Loc; i; t; pd]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -1925,7 +1955,7 @@ Grammar.safe_extend
               (let (_, c, tl, _) =
                  match ctl with
                    Qast.Tuple [xx1; xx2; xx3; xx4] -> xx1, xx2, xx3, xx4
-                 | _ -> raise (Match_failure ("q_MLast.ml", 383, 20))
+                 | _ -> raise (Match_failure ("q_MLast.ml", 384, 19))
                in
                Qast.Node ("SgExc", [Qast.Loc; c; tl]) :
                'sig_item)));
@@ -1948,22 +1978,22 @@ Grammar.safe_extend
                                                'sig_item Grammar.Entry.e)))
                                         (Grammar.s_token ("", ";")),
                                       (fun _ (s : 'sig_item) (loc : Ploc.t) ->
-                                         (s : 'e__32)))])),
-                          (fun (a : 'e__32 list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__33)));
+                                         (s : 'e__33)))])),
+                          (fun (a : 'e__33 list) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.List a) : 'e__34)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__33)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__34)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__33)))])))
+                              'e__34)))])))
              (Grammar.s_token ("", "end")),
-           (fun _ (st : 'e__33) _ (loc : Ploc.t) ->
+           (fun _ (st : 'e__34) _ (loc : Ploc.t) ->
               (Qast.Node ("SgDcl", [Qast.Loc; st]) : 'sig_item)))]];
     Grammar.extension (mod_decl_binding : 'mod_decl_binding Grammar.Entry.e)
       None
@@ -1977,32 +2007,32 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("UIDENT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__47)));
+                             (Qast.VaVal (Qast.Str a) : 'e__48)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_", loc, a) : 'e__47)));
+                             (Qast.VaAnt ("_", loc, a) : 'e__48)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                              'e__47)));
+                              'e__48)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_uid")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_uid", loc, a) : 'e__47)));
+                             (Qast.VaAnt ("_uid", loc, a) : 'e__48)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "uid")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                              'e__47)))])))
+                              'e__48)))])))
              (Grammar.s_nterm
                 (module_declaration : 'module_declaration Grammar.Entry.e)),
-           (fun (mt : 'module_declaration) (i : 'e__47) (loc : Ploc.t) ->
+           (fun (mt : 'module_declaration) (i : 'e__48) (loc : Ploc.t) ->
               (Qast.Tuple [i; mt] : 'mod_decl_binding)))]];
     Grammar.extension
       (module_declaration : 'module_declaration Grammar.Entry.e) None
@@ -2021,37 +2051,37 @@ Grammar.safe_extend
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("UIDENT", "")),
                                    (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.Str a) : 'e__48)));
+                                      (Qast.VaVal (Qast.Str a) : 'e__49)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_")),
                                    (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaAnt ("_", loc, a) : 'e__48)));
+                                      (Qast.VaAnt ("_", loc, a) : 'e__49)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                       'e__48)));
+                                       'e__49)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_uid")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_uid", loc, a) :
-                                       'e__48)));
+                                       'e__49)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "uid")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("uid", loc, a)) :
-                                       'e__48)))])))
+                                       'e__49)))])))
                       (Grammar.s_token ("", ":")))
                    (Grammar.s_nterm
                       (module_type : 'module_type Grammar.Entry.e)))
                 (Grammar.s_token ("", ")")))
              Grammar.s_self,
-           (fun (mt : 'module_declaration) _ (t : 'module_type) _ (i : 'e__48)
+           (fun (mt : 'module_declaration) _ (t : 'module_type) _ (i : 'e__49)
                 _ (loc : Ploc.t) ->
               (Qast.Node ("MtFun", [Qast.Loc; i; t; mt]) :
                'module_declaration)));
@@ -2064,6 +2094,46 @@ Grammar.safe_extend
     Grammar.extension (with_constr : 'with_constr Grammar.Entry.e) None
       [None, None,
        [Grammar.production
+          (Grammar.r_next
+             (Grammar.r_next
+                (Grammar.r_next
+                   (Grammar.r_next Grammar.r_stop
+                      (Grammar.s_token ("", "module")))
+                   (Grammar.s_facto
+                      (Grammar.s_rules
+                         [Grammar.production
+                            (Grammar.r_next Grammar.r_stop
+                               (Grammar.s_nterm
+                                  (mod_ident : 'mod_ident Grammar.Entry.e)),
+                             (fun (a : 'mod_ident) (loc : Ploc.t) ->
+                                (Qast.VaVal a : 'e__56)));
+                          Grammar.production
+                            (Grammar.r_next Grammar.r_stop
+                               (Grammar.s_token ("ANTIQUOT", "_")),
+                             (fun (a : string) (loc : Ploc.t) ->
+                                (Qast.VaAnt ("_", loc, a) : 'e__56)));
+                          Grammar.production
+                            (Grammar.r_next Grammar.r_stop
+                               (Grammar.s_token ("ANTIQUOT", "")),
+                             (fun (a : string) (loc : Ploc.t) ->
+                                (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
+                                 'e__56)));
+                          Grammar.production
+                            (Grammar.r_next Grammar.r_stop
+                               (Grammar.s_token ("ANTIQUOT", "_list")),
+                             (fun (a : string) (loc : Ploc.t) ->
+                                (Qast.VaAnt ("_list", loc, a) : 'e__56)));
+                          Grammar.production
+                            (Grammar.r_next Grammar.r_stop
+                               (Grammar.s_token ("ANTIQUOT", "list")),
+                             (fun (a : string) (loc : Ploc.t) ->
+                                (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
+                                 'e__56)))])))
+                (Grammar.s_token ("", ":=")))
+             (Grammar.s_nterm (module_expr : 'module_expr Grammar.Entry.e)),
+           (fun (me : 'module_expr) _ (i : 'e__56) _ (loc : Ploc.t) ->
+              (Qast.Node ("WcMos", [Qast.Loc; i; me]) : 'with_constr)));
+        Grammar.production
           (Grammar.r_next
              (Grammar.r_next
                 (Grammar.r_next
@@ -2099,49 +2169,9 @@ Grammar.safe_extend
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
                                  'e__55)))])))
-                (Grammar.s_token ("", ":=")))
-             (Grammar.s_nterm (module_expr : 'module_expr Grammar.Entry.e)),
-           (fun (me : 'module_expr) _ (i : 'e__55) _ (loc : Ploc.t) ->
-              (Qast.Node ("WcMos", [Qast.Loc; i; me]) : 'with_constr)));
-        Grammar.production
-          (Grammar.r_next
-             (Grammar.r_next
-                (Grammar.r_next
-                   (Grammar.r_next Grammar.r_stop
-                      (Grammar.s_token ("", "module")))
-                   (Grammar.s_facto
-                      (Grammar.s_rules
-                         [Grammar.production
-                            (Grammar.r_next Grammar.r_stop
-                               (Grammar.s_nterm
-                                  (mod_ident : 'mod_ident Grammar.Entry.e)),
-                             (fun (a : 'mod_ident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__54)));
-                          Grammar.production
-                            (Grammar.r_next Grammar.r_stop
-                               (Grammar.s_token ("ANTIQUOT", "_")),
-                             (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__54)));
-                          Grammar.production
-                            (Grammar.r_next Grammar.r_stop
-                               (Grammar.s_token ("ANTIQUOT", "")),
-                             (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__54)));
-                          Grammar.production
-                            (Grammar.r_next Grammar.r_stop
-                               (Grammar.s_token ("ANTIQUOT", "_list")),
-                             (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__54)));
-                          Grammar.production
-                            (Grammar.r_next Grammar.r_stop
-                               (Grammar.s_token ("ANTIQUOT", "list")),
-                             (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__54)))])))
                 (Grammar.s_token ("", "=")))
              (Grammar.s_nterm (module_expr : 'module_expr Grammar.Entry.e)),
-           (fun (me : 'module_expr) _ (i : 'e__54) _ (loc : Ploc.t) ->
+           (fun (me : 'module_expr) _ (i : 'e__55) _ (loc : Ploc.t) ->
               (Qast.Node ("WcMod", [Qast.Loc; i; me]) : 'with_constr)));
         Grammar.production
           (Grammar.r_next
@@ -2158,29 +2188,29 @@ Grammar.safe_extend
                                      (mod_ident :
                                       'mod_ident Grammar.Entry.e)),
                                 (fun (a : 'mod_ident) (loc : Ploc.t) ->
-                                   (Qast.VaVal a : 'e__52)));
+                                   (Qast.VaVal a : 'e__53)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__52)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__53)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__52)));
+                                    'e__53)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_list")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_list", loc, a) : 'e__52)));
+                                   (Qast.VaAnt ("_list", loc, a) : 'e__53)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "list")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                    'e__52)))])))
+                                    'e__53)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -2190,21 +2220,21 @@ Grammar.safe_extend
                                      (type_parameter :
                                       'type_parameter Grammar.Entry.e))),
                              (fun (a : 'type_parameter list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__53)));
+                                (Qast.VaVal (Qast.List a) : 'e__54)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__53)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__54)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__53)))])))
+                                 'e__54)))])))
                 (Grammar.s_token ("", ":=")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (tpl : 'e__53) (i : 'e__52) _ (loc : Ploc.t) ->
+           (fun (t : 'ctyp) _ (tpl : 'e__54) (i : 'e__53) _ (loc : Ploc.t) ->
               (Qast.Node ("WcTys", [Qast.Loc; i; tpl; t]) : 'with_constr)));
         Grammar.production
           (Grammar.r_next
@@ -2222,31 +2252,31 @@ Grammar.safe_extend
                                         (mod_ident :
                                          'mod_ident Grammar.Entry.e)),
                                    (fun (a : 'mod_ident) (loc : Ploc.t) ->
-                                      (Qast.VaVal a : 'e__49)));
+                                      (Qast.VaVal a : 'e__50)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_")),
                                    (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaAnt ("_", loc, a) : 'e__49)));
+                                      (Qast.VaAnt ("_", loc, a) : 'e__50)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                       'e__49)));
+                                       'e__50)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_list")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_list", loc, a) :
-                                       'e__49)));
+                                       'e__50)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "list")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("list", loc, a)) :
-                                       'e__49)))])))
+                                       'e__50)))])))
                       (Grammar.s_facto
                          (Grammar.s_rules
                             [Grammar.production
@@ -2257,18 +2287,18 @@ Grammar.safe_extend
                                          'type_parameter Grammar.Entry.e))),
                                 (fun (a : 'type_parameter list)
                                      (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.List a) : 'e__50)));
+                                   (Qast.VaVal (Qast.List a) : 'e__51)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_list")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_list", loc, a) : 'e__50)));
+                                   (Qast.VaAnt ("_list", loc, a) : 'e__51)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "list")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                    'e__50)))])))
+                                    'e__51)))])))
                    (Grammar.s_token ("", "=")))
                 (Grammar.s_facto
                    (Grammar.s_rules
@@ -2277,31 +2307,31 @@ Grammar.safe_extend
                             (Grammar.s_flag
                                (Grammar.s_token ("", "private"))),
                           (fun (a : bool) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Bool a) : 'e__51)));
+                             (Qast.VaVal (Qast.Bool a) : 'e__52)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__51)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__52)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__51)));
+                              'e__52)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_flag")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_flag", loc, a) : 'e__51)));
+                             (Qast.VaAnt ("_flag", loc, a) : 'e__52)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "flag")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                              'e__51)))])))
+                              'e__52)))])))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) (pf : 'e__51) _ (tpl : 'e__50) (i : 'e__49) _
+           (fun (t : 'ctyp) (pf : 'e__52) _ (tpl : 'e__51) (i : 'e__50) _
                 (loc : Ploc.t) ->
               (Qast.Node ("WcTyp", [Qast.Loc; i; tpl; pf; t]) :
                'with_constr)))]];
@@ -2325,20 +2355,20 @@ Grammar.safe_extend
                             (Grammar.s_nterm
                                (sequence : 'sequence Grammar.Entry.e)),
                           (fun (a : 'sequence) (loc : Ploc.t) ->
-                             (Qast.VaVal a : 'e__63)));
+                             (Qast.VaVal a : 'e__64)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__63)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__64)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__63)))])))
+                              'e__64)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (seq : 'e__63) _ _ (e : 'expr) _ (loc : Ploc.t) ->
+           (fun _ (seq : 'e__64) _ _ (e : 'expr) _ (loc : Ploc.t) ->
               (Qast.Node ("ExWhi", [Qast.Loc; e; seq]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -2361,7 +2391,7 @@ Grammar.safe_extend
                                                (fun (a : string)
                                                     (loc : Ploc.t) ->
                                                   (Qast.VaVal (Qast.Str a) :
-                                                   'e__60)));
+                                                   'e__61)));
                                             Grammar.production
                                               (Grammar.r_next Grammar.r_stop
                                                  (Grammar.s_token
@@ -2369,7 +2399,7 @@ Grammar.safe_extend
                                                (fun (a : string)
                                                     (loc : Ploc.t) ->
                                                   (Qast.VaAnt ("_", loc, a) :
-                                                   'e__60)));
+                                                   'e__61)));
                                             Grammar.production
                                               (Grammar.r_next Grammar.r_stop
                                                  (Grammar.s_token
@@ -2379,7 +2409,7 @@ Grammar.safe_extend
                                                   (Qast.VaVal
                                                      (Qast.VaAnt
                                                         ("", loc, a)) :
-                                                   'e__60)));
+                                                   'e__61)));
                                             Grammar.production
                                               (Grammar.r_next Grammar.r_stop
                                                  (Grammar.s_token
@@ -2388,7 +2418,7 @@ Grammar.safe_extend
                                                     (loc : Ploc.t) ->
                                                   (Qast.VaAnt
                                                      ("_lid", loc, a) :
-                                                   'e__60)));
+                                                   'e__61)));
                                             Grammar.production
                                               (Grammar.r_next Grammar.r_stop
                                                  (Grammar.s_token
@@ -2398,7 +2428,7 @@ Grammar.safe_extend
                                                   (Qast.VaVal
                                                      (Qast.VaAnt
                                                         ("lid", loc, a)) :
-                                                   'e__60)))])))
+                                                   'e__61)))])))
                                   (Grammar.s_token ("", "=")))
                                Grammar.s_self)
                             (Grammar.s_facto
@@ -2410,20 +2440,20 @@ Grammar.safe_extend
                                             'direction_flag Grammar.Entry.e)),
                                       (fun (a : 'direction_flag)
                                            (loc : Ploc.t) ->
-                                         (Qast.VaVal a : 'e__61)));
+                                         (Qast.VaVal a : 'e__62)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "_to")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_to", loc, a) :
-                                          'e__61)));
+                                          'e__62)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "to")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("to", loc, a)) :
-                                          'e__61)))])))
+                                          'e__62)))])))
                          Grammar.s_self)
                       (Grammar.s_token ("", "do")))
                    (Grammar.s_token ("", "{")))
@@ -2434,21 +2464,21 @@ Grammar.safe_extend
                             (Grammar.s_nterm
                                (sequence : 'sequence Grammar.Entry.e)),
                           (fun (a : 'sequence) (loc : Ploc.t) ->
-                             (Qast.VaVal a : 'e__62)));
+                             (Qast.VaVal a : 'e__63)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__62)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__63)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__62)))])))
+                              'e__63)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (seq : 'e__62) _ _ (e2 : 'expr) (df : 'e__61) (e1 : 'expr) _
-                (i : 'e__60) _ (loc : Ploc.t) ->
+           (fun _ (seq : 'e__63) _ _ (e2 : 'expr) (df : 'e__62) (e1 : 'expr) _
+                (i : 'e__61) _ (loc : Ploc.t) ->
               (Qast.Node ("ExFor", [Qast.Loc; i; e1; e2; df; seq]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -2464,20 +2494,20 @@ Grammar.safe_extend
                             (Grammar.s_nterm
                                (sequence : 'sequence Grammar.Entry.e)),
                           (fun (a : 'sequence) (loc : Ploc.t) ->
-                             (Qast.VaVal a : 'e__59)));
+                             (Qast.VaVal a : 'e__60)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__59)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__60)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__59)))])))
+                              'e__60)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (seq : 'e__59) _ _ (loc : Ploc.t) ->
+           (fun _ (seq : 'e__60) _ _ (loc : Ploc.t) ->
               (mksequence2 Qast.Loc seq : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -2604,34 +2634,34 @@ Grammar.safe_extend
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("UIDENT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__58)));
+                                   (Qast.VaVal (Qast.Str a) : 'e__59)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__58)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__59)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__58)));
+                                    'e__59)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_uid")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_uid", loc, a) : 'e__58)));
+                                   (Qast.VaAnt ("_uid", loc, a) : 'e__59)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "uid")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                                    'e__58)))])))
+                                    'e__59)))])))
                    (Grammar.s_nterm
                       (mod_fun_binding : 'mod_fun_binding Grammar.Entry.e)))
                 (Grammar.s_token ("", "in")))
              Grammar.s_self,
-           (fun (e : 'expr) _ (mb : 'mod_fun_binding) (m : 'e__58) _ _
+           (fun (e : 'expr) _ (mb : 'mod_fun_binding) (m : 'e__59) _ _
                 (loc : Ploc.t) ->
               (Qast.Node ("ExLmd", [Qast.Loc; m; mb; e]) : 'expr)));
         Grammar.production
@@ -2648,29 +2678,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "rec"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__56)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__57)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__56)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__57)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__56)));
+                                    'e__57)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__56)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__57)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__56)))])))
+                                    'e__57)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -2681,21 +2711,21 @@ Grammar.safe_extend
                                       'let_binding Grammar.Entry.e))
                                   (Grammar.s_token ("", "and")) false),
                              (fun (a : 'let_binding list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__57)));
+                                (Qast.VaVal (Qast.List a) : 'e__58)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__57)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__58)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__57)))])))
+                                 'e__58)))])))
                 (Grammar.s_token ("", "in")))
              Grammar.s_self,
-           (fun (x : 'expr) _ (l : 'e__57) (r : 'e__56) _ (loc : Ploc.t) ->
+           (fun (x : 'expr) _ (l : 'e__58) (r : 'e__57) _ (loc : Ploc.t) ->
               (Qast.Node ("ExLet", [Qast.Loc; r; l; x]) : 'expr)))];
        Some "where", None,
        [Grammar.production
@@ -2709,31 +2739,31 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_flag (Grammar.s_token ("", "rec"))),
                           (fun (a : bool) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Bool a) : 'e__64)));
+                             (Qast.VaVal (Qast.Bool a) : 'e__65)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__64)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__65)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__64)));
+                              'e__65)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_flag")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_flag", loc, a) : 'e__64)));
+                             (Qast.VaAnt ("_flag", loc, a) : 'e__65)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "flag")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                              'e__64)))])))
+                              'e__65)))])))
              (Grammar.s_nterm (let_binding : 'let_binding Grammar.Entry.e)),
-           (fun (lb : 'let_binding) (rf : 'e__64) _ (e : 'expr)
+           (fun (lb : 'let_binding) (rf : 'e__65) _ (e : 'expr)
                 (loc : Ploc.t) ->
               (Qast.Node
                  ("ExLet", [Qast.Loc; rf; Qast.VaVal (Qast.List [lb]); e]) :
@@ -3298,20 +3328,20 @@ Grammar.safe_extend
                                   (expr : 'expr Grammar.Entry.e))
                                (Grammar.s_token ("", ",")) false),
                           (fun (a : 'expr list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__65)));
+                             (Qast.VaVal (Qast.List a) : 'e__66)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__65)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__66)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__65)))])))
+                              'e__66)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (el : 'e__65) _ _ (e : 'expr) (loc : Ploc.t) ->
+           (fun _ (el : 'e__66) _ _ (e : 'expr) (loc : Ploc.t) ->
               (Qast.Node ("ExBae", [Qast.Loc; e; el]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -3376,20 +3406,20 @@ Grammar.safe_extend
                                   (expr : 'expr Grammar.Entry.e))
                                (Grammar.s_token ("", ",")) false),
                           (fun (a : 'expr list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__79)));
+                             (Qast.VaVal (Qast.List a) : 'e__80)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__79)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__80)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__79)))])))
+                              'e__80)))])))
              (Grammar.s_token ("", ")")),
-           (fun _ (el : 'e__79) _ (loc : Ploc.t) ->
+           (fun _ (el : 'e__80) _ (loc : Ploc.t) ->
               (Qast.Node ("ExTup", [Qast.Loc; el]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -3486,20 +3516,20 @@ Grammar.safe_extend
                                   (label_expr : 'label_expr Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'label_expr list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__78)));
+                             (Qast.VaVal (Qast.List a) : 'e__79)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__78)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__79)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__78)))])))
+                              'e__79)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (lel : 'e__78) _ _ (e : 'expr) _ _ (loc : Ploc.t) ->
+           (fun _ (lel : 'e__79) _ _ (e : 'expr) _ _ (loc : Ploc.t) ->
               (Qast.Node ("ExRec", [Qast.Loc; lel; Qast.Option (Some e)]) :
                'expr)));
         Grammar.production
@@ -3515,20 +3545,20 @@ Grammar.safe_extend
                                   (label_expr : 'label_expr Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'label_expr list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__77)));
+                             (Qast.VaVal (Qast.List a) : 'e__78)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__77)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__78)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__77)))])))
+                              'e__78)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (lel : 'e__77) _ (loc : Ploc.t) ->
+           (fun _ (lel : 'e__78) _ (loc : Ploc.t) ->
               (Qast.Node ("ExRec", [Qast.Loc; lel; Qast.Option None]) :
                'expr)));
         Grammar.production
@@ -3544,20 +3574,20 @@ Grammar.safe_extend
                                   (expr : 'expr Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'expr list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__76)));
+                             (Qast.VaVal (Qast.List a) : 'e__77)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__76)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__77)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__76)))])))
+                              'e__77)))])))
              (Grammar.s_token ("", "|]")),
-           (fun _ (el : 'e__76) _ (loc : Ploc.t) ->
+           (fun _ (el : 'e__77) _ (loc : Ploc.t) ->
               (Qast.Node ("ExArr", [Qast.Loc; el]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -3588,29 +3618,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__75)));
+                          (Qast.VaVal (Qast.Str a) : 'e__76)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__75)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__76)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__75)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__76)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_uid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__75)));
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__76)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "uid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__75)))])),
-           (fun (i : 'e__75) (loc : Ploc.t) ->
+                           'e__76)))])),
+           (fun (i : 'e__76) (loc : Ploc.t) ->
               (Qast.Node ("ExUid", [Qast.Loc; i]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3620,8 +3650,8 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("GIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__74)))])),
-           (fun (i : 'e__74) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Str a) : 'e__75)))])),
+           (fun (i : 'e__75) (loc : Ploc.t) ->
               (Qast.Node ("ExLid", [Qast.Loc; i]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3631,29 +3661,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__73)));
+                          (Qast.VaVal (Qast.Str a) : 'e__74)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__73)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__74)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__73)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__74)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__73)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__74)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__73)))])),
-           (fun (i : 'e__73) (loc : Ploc.t) ->
+                           'e__74)))])),
+           (fun (i : 'e__74) (loc : Ploc.t) ->
               (Qast.Node ("ExLid", [Qast.Loc; i]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3663,19 +3693,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("CHAR", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__72)));
+                          (Qast.VaVal (Qast.Str a) : 'e__73)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_chr")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_chr", loc, a) : 'e__72)));
+                          (Qast.VaAnt ("_chr", loc, a) : 'e__73)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "chr")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("chr", loc, a)) :
-                           'e__72)))])),
-           (fun (s : 'e__72) (loc : Ploc.t) ->
+                           'e__73)))])),
+           (fun (s : 'e__73) (loc : Ploc.t) ->
               (Qast.Node ("ExChr", [Qast.Loc; s]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3685,19 +3715,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("STRING", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__71)));
+                          (Qast.VaVal (Qast.Str a) : 'e__72)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_str")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_str", loc, a) : 'e__71)));
+                          (Qast.VaAnt ("_str", loc, a) : 'e__72)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "str")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("str", loc, a)) :
-                           'e__71)))])),
-           (fun (s : 'e__71) (loc : Ploc.t) ->
+                           'e__72)))])),
+           (fun (s : 'e__72) (loc : Ploc.t) ->
               (Qast.Node ("ExStr", [Qast.Loc; s]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3707,19 +3737,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("FLOAT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__70)));
+                          (Qast.VaVal (Qast.Str a) : 'e__71)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_flo")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_flo", loc, a) : 'e__70)));
+                          (Qast.VaAnt ("_flo", loc, a) : 'e__71)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "flo")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("flo", loc, a)) :
-                           'e__70)))])),
-           (fun (s : 'e__70) (loc : Ploc.t) ->
+                           'e__71)))])),
+           (fun (s : 'e__71) (loc : Ploc.t) ->
               (Qast.Node ("ExFlo", [Qast.Loc; s]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3729,19 +3759,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT_n", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__69)));
+                          (Qast.VaVal (Qast.Str a) : 'e__70)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_nativeint")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_nativeint", loc, a) : 'e__69)));
+                          (Qast.VaAnt ("_nativeint", loc, a) : 'e__70)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "nativeint")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("nativeint", loc, a)) :
-                           'e__69)))])),
-           (fun (s : 'e__69) (loc : Ploc.t) ->
+                           'e__70)))])),
+           (fun (s : 'e__70) (loc : Ploc.t) ->
               (Qast.Node ("ExInt", [Qast.Loc; s; Qast.Str "n"]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3751,19 +3781,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT_L", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__68)));
+                          (Qast.VaVal (Qast.Str a) : 'e__69)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_int64")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_int64", loc, a) : 'e__68)));
+                          (Qast.VaAnt ("_int64", loc, a) : 'e__69)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "int64")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("int64", loc, a)) :
-                           'e__68)))])),
-           (fun (s : 'e__68) (loc : Ploc.t) ->
+                           'e__69)))])),
+           (fun (s : 'e__69) (loc : Ploc.t) ->
               (Qast.Node ("ExInt", [Qast.Loc; s; Qast.Str "L"]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3773,19 +3803,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT_l", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__67)));
+                          (Qast.VaVal (Qast.Str a) : 'e__68)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_int32")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_int32", loc, a) : 'e__67)));
+                          (Qast.VaAnt ("_int32", loc, a) : 'e__68)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "int32")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("int32", loc, a)) :
-                           'e__67)))])),
-           (fun (s : 'e__67) (loc : Ploc.t) ->
+                           'e__68)))])),
+           (fun (s : 'e__68) (loc : Ploc.t) ->
               (Qast.Node ("ExInt", [Qast.Loc; s; Qast.Str "l"]) : 'expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -3795,19 +3825,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__66)));
+                          (Qast.VaVal (Qast.Str a) : 'e__67)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_int")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_int", loc, a) : 'e__66)));
+                          (Qast.VaAnt ("_int", loc, a) : 'e__67)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "int")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("int", loc, a)) :
-                           'e__66)))])),
-           (fun (s : 'e__66) (loc : Ploc.t) ->
+                           'e__67)))])),
+           (fun (s : 'e__67) (loc : Ploc.t) ->
               (Qast.Node ("ExInt", [Qast.Loc; s; Qast.Str ""]) : 'expr)))]];
     Grammar.extension (closed_case_list : 'closed_case_list Grammar.Entry.e)
       None
@@ -3816,6 +3846,33 @@ Grammar.safe_extend
           (Grammar.r_next
              (Grammar.r_next
                 (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "|")))
+                (Grammar.s_facto
+                   (Grammar.s_rules
+                      [Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_list0sep
+                               (Grammar.s_nterm
+                                  (match_case : 'match_case Grammar.Entry.e))
+                               (Grammar.s_token ("", "|")) false),
+                          (fun (a : 'match_case list) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.List a) : 'e__82)));
+                       Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("ANTIQUOT", "_list")),
+                          (fun (a : string) (loc : Ploc.t) ->
+                             (Qast.VaAnt ("_list", loc, a) : 'e__82)));
+                       Grammar.production
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("ANTIQUOT", "list")),
+                          (fun (a : string) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
+                              'e__82)))])))
+             (Grammar.s_token ("", "end")),
+           (fun _ (l : 'e__82) _ (loc : Ploc.t) -> (l : 'closed_case_list)));
+        Grammar.production
+          (Grammar.r_next
+             (Grammar.r_next
+                (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "[")))
                 (Grammar.s_facto
                    (Grammar.s_rules
                       [Grammar.production
@@ -3837,35 +3894,8 @@ Grammar.safe_extend
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
                               'e__81)))])))
-             (Grammar.s_token ("", "end")),
-           (fun _ (l : 'e__81) _ (loc : Ploc.t) -> (l : 'closed_case_list)));
-        Grammar.production
-          (Grammar.r_next
-             (Grammar.r_next
-                (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "[")))
-                (Grammar.s_facto
-                   (Grammar.s_rules
-                      [Grammar.production
-                         (Grammar.r_next Grammar.r_stop
-                            (Grammar.s_list0sep
-                               (Grammar.s_nterm
-                                  (match_case : 'match_case Grammar.Entry.e))
-                               (Grammar.s_token ("", "|")) false),
-                          (fun (a : 'match_case list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__80)));
-                       Grammar.production
-                         (Grammar.r_next Grammar.r_stop
-                            (Grammar.s_token ("ANTIQUOT", "_list")),
-                          (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__80)));
-                       Grammar.production
-                         (Grammar.r_next Grammar.r_stop
-                            (Grammar.s_token ("ANTIQUOT", "list")),
-                          (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__80)))])))
              (Grammar.s_token ("", "]")),
-           (fun _ (l : 'e__80) _ (loc : Ploc.t) ->
+           (fun _ (l : 'e__81) _ (loc : Ploc.t) ->
               (l : 'closed_case_list)))]];
     Grammar.extension (cons_expr_opt : 'cons_expr_opt Grammar.Entry.e) None
       [None, None,
@@ -3935,34 +3965,34 @@ Grammar.safe_extend
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("UIDENT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__84)));
+                                   (Qast.VaVal (Qast.Str a) : 'e__85)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__84)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__85)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__84)));
+                                    'e__85)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_uid")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_uid", loc, a) : 'e__84)));
+                                   (Qast.VaAnt ("_uid", loc, a) : 'e__85)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "uid")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                                    'e__84)))])))
+                                    'e__85)))])))
                    (Grammar.s_nterm
                       (mod_fun_binding : 'mod_fun_binding Grammar.Entry.e)))
                 (Grammar.s_token ("", "in")))
              Grammar.s_self,
-           (fun (el : 'sequence) _ (mb : 'mod_fun_binding) (m : 'e__84) _ _
+           (fun (el : 'sequence) _ (mb : 'mod_fun_binding) (m : 'e__85) _ _
                 (loc : Ploc.t) ->
               (Qast.List
                  [Qast.Node
@@ -3982,29 +4012,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "rec"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__82)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__83)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__82)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__83)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__82)));
+                                    'e__83)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__82)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__83)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__82)))])))
+                                    'e__83)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -4015,21 +4045,21 @@ Grammar.safe_extend
                                       'let_binding Grammar.Entry.e))
                                   (Grammar.s_token ("", "and")) false),
                              (fun (a : 'let_binding list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__83)));
+                                (Qast.VaVal (Qast.List a) : 'e__84)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__83)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__84)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__83)))])))
+                                 'e__84)))])))
                 (Grammar.s_token ("", "in")))
              Grammar.s_self,
-           (fun (el : 'sequence) _ (l : 'e__83) (rf : 'e__82) _
+           (fun (el : 'sequence) _ (l : 'e__84) (rf : 'e__83) _
                 (loc : Ploc.t) ->
               (Qast.List
                  [Qast.Node
@@ -4095,21 +4125,21 @@ Grammar.safe_extend
                                      (when_expr :
                                       'when_expr Grammar.Entry.e))),
                              (fun (a : 'when_expr option) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Option a) : 'e__85)));
+                                (Qast.VaVal (Qast.Option a) : 'e__86)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_opt")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_opt", loc, a) : 'e__85)));
+                                (Qast.VaAnt ("_opt", loc, a) : 'e__86)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "opt")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                 'e__85)))])))
+                                 'e__86)))])))
                 (Grammar.s_token ("", "->")))
              (Grammar.s_nterm (expr : 'expr Grammar.Entry.e)),
-           (fun (e : 'expr) _ (w : 'e__85) (aso : 'as_patt_opt) (p : 'patt)
+           (fun (e : 'expr) _ (w : 'e__86) (aso : 'as_patt_opt) (p : 'patt)
                 (loc : Ploc.t) ->
               (mkmatchcase Qast.Loc p aso w e : 'match_case)))]];
     Grammar.extension (as_patt_opt : 'as_patt_opt Grammar.Entry.e) None
@@ -4223,20 +4253,20 @@ Grammar.safe_extend
                                   (label_patt : 'label_patt Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'label_patt list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__97)));
+                             (Qast.VaVal (Qast.List a) : 'e__98)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__97)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__98)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__97)))])))
+                              'e__98)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (lpl : 'e__97) _ (loc : Ploc.t) ->
+           (fun _ (lpl : 'e__98) _ (loc : Ploc.t) ->
               (Qast.Node ("PaRec", [Qast.Loc; lpl]) : 'patt)));
         Grammar.production
           (Grammar.r_next
@@ -4251,20 +4281,20 @@ Grammar.safe_extend
                                   (patt : 'patt Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'patt list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__96)));
+                             (Qast.VaVal (Qast.List a) : 'e__97)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__96)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__97)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__96)))])))
+                              'e__97)))])))
              (Grammar.s_token ("", "|]")),
-           (fun _ (pl : 'e__96) _ (loc : Ploc.t) ->
+           (fun _ (pl : 'e__97) _ (loc : Ploc.t) ->
               (Qast.Node ("PaArr", [Qast.Loc; pl]) : 'patt)));
         Grammar.production
           (Grammar.r_next
@@ -4338,19 +4368,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("CHAR", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__95)));
+                          (Qast.VaVal (Qast.Str a) : 'e__96)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_chr")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_chr", loc, a) : 'e__95)));
+                          (Qast.VaAnt ("_chr", loc, a) : 'e__96)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "chr")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("chr", loc, a)) :
-                           'e__95)))])),
-           (fun (s : 'e__95) (loc : Ploc.t) ->
+                           'e__96)))])),
+           (fun (s : 'e__96) (loc : Ploc.t) ->
               (Qast.Node ("PaChr", [Qast.Loc; s]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4360,19 +4390,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("STRING", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__94)));
+                          (Qast.VaVal (Qast.Str a) : 'e__95)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_str")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_str", loc, a) : 'e__94)));
+                          (Qast.VaAnt ("_str", loc, a) : 'e__95)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "str")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("str", loc, a)) :
-                           'e__94)))])),
-           (fun (s : 'e__94) (loc : Ploc.t) ->
+                           'e__95)))])),
+           (fun (s : 'e__95) (loc : Ploc.t) ->
               (Qast.Node ("PaStr", [Qast.Loc; s]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4382,19 +4412,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("FLOAT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__93)));
+                          (Qast.VaVal (Qast.Str a) : 'e__94)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_flo")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_flo", loc, a) : 'e__93)));
+                          (Qast.VaAnt ("_flo", loc, a) : 'e__94)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "flo")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("flo", loc, a)) :
-                           'e__93)))])),
-           (fun (s : 'e__93) (loc : Ploc.t) ->
+                           'e__94)))])),
+           (fun (s : 'e__94) (loc : Ploc.t) ->
               (Qast.Node ("PaFlo", [Qast.Loc; s]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4404,19 +4434,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT_n", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__92)));
+                          (Qast.VaVal (Qast.Str a) : 'e__93)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_nativeint")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_nativeint", loc, a) : 'e__92)));
+                          (Qast.VaAnt ("_nativeint", loc, a) : 'e__93)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "nativeint")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("nativeint", loc, a)) :
-                           'e__92)))])),
-           (fun (s : 'e__92) (loc : Ploc.t) ->
+                           'e__93)))])),
+           (fun (s : 'e__93) (loc : Ploc.t) ->
               (Qast.Node ("PaInt", [Qast.Loc; s; Qast.Str "n"]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4426,19 +4456,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT_L", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__91)));
+                          (Qast.VaVal (Qast.Str a) : 'e__92)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_int64")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_int64", loc, a) : 'e__91)));
+                          (Qast.VaAnt ("_int64", loc, a) : 'e__92)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "int64")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("int64", loc, a)) :
-                           'e__91)))])),
-           (fun (s : 'e__91) (loc : Ploc.t) ->
+                           'e__92)))])),
+           (fun (s : 'e__92) (loc : Ploc.t) ->
               (Qast.Node ("PaInt", [Qast.Loc; s; Qast.Str "L"]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4448,19 +4478,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT_l", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__90)));
+                          (Qast.VaVal (Qast.Str a) : 'e__91)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_int32")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_int32", loc, a) : 'e__90)));
+                          (Qast.VaAnt ("_int32", loc, a) : 'e__91)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "int32")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("int32", loc, a)) :
-                           'e__90)))])),
-           (fun (s : 'e__90) (loc : Ploc.t) ->
+                           'e__91)))])),
+           (fun (s : 'e__91) (loc : Ploc.t) ->
               (Qast.Node ("PaInt", [Qast.Loc; s; Qast.Str "l"]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4470,19 +4500,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("INT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__89)));
+                          (Qast.VaVal (Qast.Str a) : 'e__90)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_int")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_int", loc, a) : 'e__89)));
+                          (Qast.VaAnt ("_int", loc, a) : 'e__90)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "int")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("int", loc, a)) :
-                           'e__89)))])),
-           (fun (s : 'e__89) (loc : Ploc.t) ->
+                           'e__90)))])),
+           (fun (s : 'e__90) (loc : Ploc.t) ->
               (Qast.Node ("PaInt", [Qast.Loc; s; Qast.Str ""]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4492,29 +4522,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__88)));
+                          (Qast.VaVal (Qast.Str a) : 'e__89)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__88)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__89)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__88)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__89)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_uid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__88)));
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__89)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "uid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__88)))])),
-           (fun (s : 'e__88) (loc : Ploc.t) ->
+                           'e__89)))])),
+           (fun (s : 'e__89) (loc : Ploc.t) ->
               (Qast.Node ("PaUid", [Qast.Loc; s]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4524,8 +4554,8 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("GIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__87)))])),
-           (fun (s : 'e__87) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Str a) : 'e__88)))])),
+           (fun (s : 'e__88) (loc : Ploc.t) ->
               (Qast.Node ("PaLid", [Qast.Loc; s]) : 'patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4535,29 +4565,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__86)));
+                          (Qast.VaVal (Qast.Str a) : 'e__87)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__86)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__87)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__86)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__87)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__86)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__87)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__86)))])),
-           (fun (s : 'e__86) (loc : Ploc.t) ->
+                           'e__87)))])),
+           (fun (s : 'e__87) (loc : Ploc.t) ->
               (Qast.Node ("PaLid", [Qast.Loc; s]) : 'patt)))]];
     Grammar.extension (paren_patt : 'paren_patt Grammar.Entry.e) None
       [None, None,
@@ -4575,29 +4605,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__101)));
+                          (Qast.VaVal (Qast.Str a) : 'e__102)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__101)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__102)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__101)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__102)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_uid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__101)));
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__102)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "uid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__101)))])),
-           (fun (s : 'e__101) _ (loc : Ploc.t) ->
+                           'e__102)))])),
+           (fun (s : 'e__102) _ (loc : Ploc.t) ->
               (Qast.Node ("PaUnp", [Qast.Loc; s; Qast.Option None]) :
                'paren_patt)));
         Grammar.production
@@ -4612,32 +4642,32 @@ Grammar.safe_extend
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("UIDENT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Str a) : 'e__100)));
+                                (Qast.VaVal (Qast.Str a) : 'e__101)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__100)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__101)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__100)));
+                                 'e__101)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_uid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_uid", loc, a) : 'e__100)));
+                                (Qast.VaAnt ("_uid", loc, a) : 'e__101)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "uid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                                 'e__100)))])))
+                                 'e__101)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (module_type : 'module_type Grammar.Entry.e)),
-           (fun (mt : 'module_type) _ (s : 'e__100) _ (loc : Ploc.t) ->
+           (fun (mt : 'module_type) _ (s : 'e__101) _ (loc : Ploc.t) ->
               (Qast.Node ("PaUnp", [Qast.Loc; s; Qast.Option (Some mt)]) :
                'paren_patt)));
         Grammar.production
@@ -4649,29 +4679,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__99)));
+                          (Qast.VaVal (Qast.Str a) : 'e__100)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__99)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__100)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__99)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__100)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__99)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__100)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__99)))])),
-           (fun (s : 'e__99) _ (loc : Ploc.t) ->
+                           'e__100)))])),
+           (fun (s : 'e__100) _ (loc : Ploc.t) ->
               (Qast.Node ("PaNty", [Qast.Loc; s]) : 'paren_patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4683,19 +4713,19 @@ Grammar.safe_extend
                             (Grammar.s_nterm (patt : 'patt Grammar.Entry.e))
                             (Grammar.s_token ("", ",")) false),
                        (fun (a : 'patt list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__98)));
+                          (Qast.VaVal (Qast.List a) : 'e__99)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__98)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__99)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__98)))])),
-           (fun (pl : 'e__98) (loc : Ploc.t) ->
+                           'e__99)))])),
+           (fun (pl : 'e__99) (loc : Ploc.t) ->
               (Qast.Node ("PaTup", [Qast.Loc; pl]) : 'paren_patt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4778,6 +4808,38 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Str a) : 'e__104)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "_")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaAnt ("_", loc, a) : 'e__104)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__104)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "_lid")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__104)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "lid")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
+                           'e__104)))])),
+           (fun (i : 'e__104) (loc : Ploc.t) ->
+              (Qast.Node ("PaLid", [Qast.Loc; i]) : 'patt_label_ident)));
+        Grammar.production
+          (Grammar.r_next Grammar.r_stop
+             (Grammar.s_facto
+                (Grammar.s_rules
+                   [Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("UIDENT", "")),
+                       (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.Str a) : 'e__103)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
@@ -4791,48 +4853,16 @@ Grammar.safe_extend
                           (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__103)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "_lid")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__103)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "lid")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__103)))])),
-           (fun (i : 'e__103) (loc : Ploc.t) ->
-              (Qast.Node ("PaLid", [Qast.Loc; i]) : 'patt_label_ident)));
-        Grammar.production
-          (Grammar.r_next Grammar.r_stop
-             (Grammar.s_facto
-                (Grammar.s_rules
-                   [Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("UIDENT", "")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__102)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "_")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__102)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__102)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_uid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__102)));
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__103)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "uid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__102)))])),
-           (fun (i : 'e__102) (loc : Ploc.t) ->
+                           'e__103)))])),
+           (fun (i : 'e__103) (loc : Ploc.t) ->
               (Qast.Node ("PaUid", [Qast.Loc; i]) : 'patt_label_ident)))]];
     Grammar.extension (ipatt : 'ipatt Grammar.Entry.e) None
       [None, None,
@@ -4848,8 +4878,8 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("GIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__106)))])),
-           (fun (s : 'e__106) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Str a) : 'e__107)))])),
+           (fun (s : 'e__107) (loc : Ploc.t) ->
               (Qast.Node ("PaLid", [Qast.Loc; s]) : 'ipatt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -4859,29 +4889,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__105)));
+                          (Qast.VaVal (Qast.Str a) : 'e__106)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__105)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__106)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__105)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__106)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__105)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__106)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__105)))])),
-           (fun (s : 'e__105) (loc : Ploc.t) ->
+                           'e__106)))])),
+           (fun (s : 'e__106) (loc : Ploc.t) ->
               (Qast.Node ("PaLid", [Qast.Loc; s]) : 'ipatt)));
         Grammar.production
           (Grammar.r_next
@@ -4905,20 +4935,20 @@ Grammar.safe_extend
                                    'label_ipatt Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'label_ipatt list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__104)));
+                             (Qast.VaVal (Qast.List a) : 'e__105)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__104)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__105)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__104)))])))
+                              'e__105)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (lpl : 'e__104) _ (loc : Ploc.t) ->
+           (fun _ (lpl : 'e__105) _ (loc : Ploc.t) ->
               (Qast.Node ("PaRec", [Qast.Loc; lpl]) : 'ipatt)))]];
     Grammar.extension (paren_ipatt : 'paren_ipatt Grammar.Entry.e) None
       [None, None,
@@ -4936,29 +4966,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__110)));
+                          (Qast.VaVal (Qast.Str a) : 'e__111)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__110)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__111)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__110)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__111)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_uid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__110)));
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__111)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "uid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__110)))])),
-           (fun (s : 'e__110) _ (loc : Ploc.t) ->
+                           'e__111)))])),
+           (fun (s : 'e__111) _ (loc : Ploc.t) ->
               (Qast.Node ("PaUnp", [Qast.Loc; s; Qast.Option None]) :
                'paren_ipatt)));
         Grammar.production
@@ -4973,32 +5003,32 @@ Grammar.safe_extend
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("UIDENT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Str a) : 'e__109)));
+                                (Qast.VaVal (Qast.Str a) : 'e__110)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__109)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__110)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__109)));
+                                 'e__110)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_uid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_uid", loc, a) : 'e__109)));
+                                (Qast.VaAnt ("_uid", loc, a) : 'e__110)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "uid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                                 'e__109)))])))
+                                 'e__110)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (module_type : 'module_type Grammar.Entry.e)),
-           (fun (mt : 'module_type) _ (s : 'e__109) _ (loc : Ploc.t) ->
+           (fun (mt : 'module_type) _ (s : 'e__110) _ (loc : Ploc.t) ->
               (Qast.Node ("PaUnp", [Qast.Loc; s; Qast.Option (Some mt)]) :
                'paren_ipatt)));
         Grammar.production
@@ -5010,29 +5040,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__108)));
+                          (Qast.VaVal (Qast.Str a) : 'e__109)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__108)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__109)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__108)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__109)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__108)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__109)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__108)))])),
-           (fun (s : 'e__108) _ (loc : Ploc.t) ->
+                           'e__109)))])),
+           (fun (s : 'e__109) _ (loc : Ploc.t) ->
               (Qast.Node ("PaNty", [Qast.Loc; s]) : 'paren_ipatt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -5044,19 +5074,19 @@ Grammar.safe_extend
                             (Grammar.s_nterm (ipatt : 'ipatt Grammar.Entry.e))
                             (Grammar.s_token ("", ",")) false),
                        (fun (a : 'ipatt list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__107)));
+                          (Qast.VaVal (Qast.List a) : 'e__108)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__107)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__108)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__107)))])),
-           (fun (pl : 'e__107) (loc : Ploc.t) ->
+                           'e__108)))])),
+           (fun (pl : 'e__108) (loc : Ploc.t) ->
               (Qast.Node ("PaTup", [Qast.Loc; pl]) : 'paren_ipatt)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -5120,20 +5150,20 @@ Grammar.safe_extend
                                            (type_patt :
                                             'type_patt Grammar.Entry.e)),
                                       (fun (a : 'type_patt) (loc : Ploc.t) ->
-                                         (Qast.VaVal a : 'e__111)));
+                                         (Qast.VaVal a : 'e__112)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "_tp")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_tp", loc, a) :
-                                          'e__111)));
+                                          'e__112)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "tp")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("tp", loc, a)) :
-                                          'e__111)))])))
+                                          'e__112)))])))
                          (Grammar.s_facto
                             (Grammar.s_rules
                                [Grammar.production
@@ -5145,20 +5175,20 @@ Grammar.safe_extend
                                               Grammar.Entry.e))),
                                    (fun (a : 'type_parameter list)
                                         (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.List a) : 'e__112)));
+                                      (Qast.VaVal (Qast.List a) : 'e__113)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_list")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_list", loc, a) :
-                                       'e__112)));
+                                       'e__113)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "list")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("list", loc, a)) :
-                                       'e__112)))])))
+                                       'e__113)))])))
                       (Grammar.s_token ("", "=")))
                    (Grammar.s_facto
                       (Grammar.s_rules
@@ -5167,18 +5197,18 @@ Grammar.safe_extend
                                (Grammar.s_flag
                                   (Grammar.s_token ("", "private"))),
                              (fun (a : bool) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Bool a) : 'e__113)));
+                                (Qast.VaVal (Qast.Bool a) : 'e__114)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_priv")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_priv", loc, a) : 'e__113)));
+                                (Qast.VaAnt ("_priv", loc, a) : 'e__114)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "priv")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("priv", loc, a)) :
-                                 'e__113)))])))
+                                 'e__114)))])))
                 (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)))
              (Grammar.s_facto
                 (Grammar.s_rules
@@ -5188,20 +5218,20 @@ Grammar.safe_extend
                             (Grammar.s_nterm
                                (constrain : 'constrain Grammar.Entry.e))),
                        (fun (a : 'constrain list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__114)));
+                          (Qast.VaVal (Qast.List a) : 'e__115)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__114)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__115)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__114)))])),
-           (fun (cl : 'e__114) (tk : 'ctyp) (pf : 'e__113) _ (tpl : 'e__112)
-                (n : 'e__111) (loc : Ploc.t) ->
+                           'e__115)))])),
+           (fun (cl : 'e__115) (tk : 'ctyp) (pf : 'e__114) _ (tpl : 'e__113)
+                (n : 'e__112) (loc : Ploc.t) ->
               (Qast.Record
                  ["tdNam", n; "tdPrm", tpl; "tdPrv", pf; "tdDef", tk;
                   "tdCon", cl] :
@@ -5216,29 +5246,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__115)));
+                          (Qast.VaVal (Qast.Str a) : 'e__116)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__115)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__116)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__115)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__116)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__115)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__116)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__115)))])),
-           (fun (n : 'e__115) (loc : Ploc.t) ->
+                           'e__116)))])),
+           (fun (n : 'e__116) (loc : Ploc.t) ->
               (Qast.Tuple [Qast.Loc; n] : 'type_patt)))]];
     Grammar.extension (constrain : 'constrain Grammar.Entry.e) None
       [None, None,
@@ -5265,8 +5295,8 @@ Grammar.safe_extend
                             (simple_type_parameter :
                              'simple_type_parameter Grammar.Entry.e)),
                        (fun (a : 'simple_type_parameter) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__118)))])),
-           (fun (p : 'e__118) (loc : Ploc.t) ->
+                          (Qast.VaVal a : 'e__119)))])),
+           (fun (p : 'e__119) (loc : Ploc.t) ->
               (Qast.Tuple [p; Qast.Option None] : 'type_parameter)));
         Grammar.production
           (Grammar.r_next
@@ -5279,8 +5309,8 @@ Grammar.safe_extend
                             (simple_type_parameter :
                              'simple_type_parameter Grammar.Entry.e)),
                        (fun (a : 'simple_type_parameter) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__117)))])),
-           (fun (p : 'e__117) _ (loc : Ploc.t) ->
+                          (Qast.VaVal a : 'e__118)))])),
+           (fun (p : 'e__118) _ (loc : Ploc.t) ->
               (Qast.Tuple [p; Qast.Option (Some (Qast.Bool false))] :
                'type_parameter)));
         Grammar.production
@@ -5294,8 +5324,8 @@ Grammar.safe_extend
                             (simple_type_parameter :
                              'simple_type_parameter Grammar.Entry.e)),
                        (fun (a : 'simple_type_parameter) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__116)))])),
-           (fun (p : 'e__116) _ (loc : Ploc.t) ->
+                          (Qast.VaVal a : 'e__117)))])),
+           (fun (p : 'e__117) _ (loc : Ploc.t) ->
               (Qast.Tuple [p; Qast.Option (Some (Qast.Bool true))] :
                'type_parameter)))]];
     Grammar.extension
@@ -5330,20 +5360,20 @@ Grammar.safe_extend
                             (Grammar.s_flag
                                (Grammar.s_token ("", "private"))),
                           (fun (a : bool) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Bool a) : 'e__119)));
+                             (Qast.VaVal (Qast.Bool a) : 'e__120)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_priv")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_priv", loc, a) : 'e__119)));
+                             (Qast.VaAnt ("_priv", loc, a) : 'e__120)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "priv")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("priv", loc, a)) :
-                              'e__119)))])))
+                              'e__120)))])))
              Grammar.s_self,
-           (fun (t2 : 'ctyp) (pf : 'e__119) _ (t1 : 'ctyp) (loc : Ploc.t) ->
+           (fun (t2 : 'ctyp) (pf : 'e__120) _ (t1 : 'ctyp) (loc : Ploc.t) ->
               (Qast.Node ("TyMan", [Qast.Loc; t1; pf; t2]) : 'ctyp)))];
        Some "as", Some Gramext.LeftA,
        [Grammar.production
@@ -5370,21 +5400,21 @@ Grammar.safe_extend
                                 (Qast.VaVal
                                    (Qast.List
                                       (List.map (fun a -> Qast.Str a) a)) :
-                                 'e__121)));
+                                 'e__122)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__121)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__122)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__121)))])))
+                                 'e__122)))])))
                 (Grammar.s_token ("", ".")))
              Grammar.s_self,
-           (fun (t : 'ctyp) _ (pl : 'e__121) _ (loc : Ploc.t) ->
+           (fun (t : 'ctyp) _ (pl : 'e__122) _ (loc : Ploc.t) ->
               (Qast.Node ("TyPot", [Qast.Loc; pl; t]) : 'ctyp)));
         Grammar.production
           (Grammar.r_next
@@ -5399,21 +5429,21 @@ Grammar.safe_extend
                                   (Grammar.s_nterm
                                      (typevar : 'typevar Grammar.Entry.e))),
                              (fun (a : 'typevar list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__120)));
+                                (Qast.VaVal (Qast.List a) : 'e__121)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__120)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__121)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__120)))])))
+                                 'e__121)))])))
                 (Grammar.s_token ("", ".")))
              Grammar.s_self,
-           (fun (t : 'ctyp) _ (pl : 'e__120) _ (loc : Ploc.t) ->
+           (fun (t : 'ctyp) _ (pl : 'e__121) _ (loc : Ploc.t) ->
               (Qast.Node ("TyPol", [Qast.Loc; pl; t]) : 'ctyp)))];
        Some "arrow", Some Gramext.RightA,
        [Grammar.production
@@ -5452,20 +5482,20 @@ Grammar.safe_extend
                                    'label_declaration Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'label_declaration list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__127)));
+                             (Qast.VaVal (Qast.List a) : 'e__128)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__127)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__128)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__127)))])))
+                              'e__128)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (ldl : 'e__127) _ (loc : Ploc.t) ->
+           (fun _ (ldl : 'e__128) _ (loc : Ploc.t) ->
               (Qast.Node ("TyRec", [Qast.Loc; ldl]) : 'ctyp)));
         Grammar.production
           (Grammar.r_next
@@ -5482,20 +5512,20 @@ Grammar.safe_extend
                                (Grammar.s_token ("", "|")) false),
                           (fun (a : 'constructor_declaration list)
                                (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__126)));
+                             (Qast.VaVal (Qast.List a) : 'e__127)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__126)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__127)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__126)))])))
+                              'e__127)))])))
              (Grammar.s_token ("", "]")),
-           (fun _ (cdl : 'e__126) _ (loc : Ploc.t) ->
+           (fun _ (cdl : 'e__127) _ (loc : Ploc.t) ->
               (Qast.Node ("TySum", [Qast.Loc; cdl]) : 'ctyp)));
         Grammar.production
           (Grammar.r_next
@@ -5510,20 +5540,20 @@ Grammar.safe_extend
                                   (ctyp : 'ctyp Grammar.Entry.e))
                                (Grammar.s_token ("", "*")) false),
                           (fun (a : 'ctyp list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__125)));
+                             (Qast.VaVal (Qast.List a) : 'e__126)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__125)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__126)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__125)))])))
+                              'e__126)))])))
              (Grammar.s_token ("", ")")),
-           (fun _ (tl : 'e__125) _ (loc : Ploc.t) ->
+           (fun _ (tl : 'e__126) _ (loc : Ploc.t) ->
               (Qast.Node ("TyTup", [Qast.Loc; tl]) : 'ctyp)));
         Grammar.production
           (Grammar.r_next
@@ -5561,6 +5591,38 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Str a) : 'e__125)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "_")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaAnt ("_", loc, a) : 'e__125)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__125)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "_uid")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__125)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "uid")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
+                           'e__125)))])),
+           (fun (i : 'e__125) (loc : Ploc.t) ->
+              (Qast.Node ("TyUid", [Qast.Loc; i]) : 'ctyp)));
+        Grammar.production
+          (Grammar.r_next Grammar.r_stop
+             (Grammar.s_facto
+                (Grammar.s_rules
+                   [Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("LIDENT", "")),
+                       (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.Str a) : 'e__124)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
@@ -5574,48 +5636,16 @@ Grammar.safe_extend
                           (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__124)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "_uid")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__124)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "uid")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__124)))])),
-           (fun (i : 'e__124) (loc : Ploc.t) ->
-              (Qast.Node ("TyUid", [Qast.Loc; i]) : 'ctyp)));
-        Grammar.production
-          (Grammar.r_next Grammar.r_stop
-             (Grammar.s_facto
-                (Grammar.s_rules
-                   [Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("LIDENT", "")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__123)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "_")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__123)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__123)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__123)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__124)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__123)))])),
-           (fun (i : 'e__123) (loc : Ploc.t) ->
+                           'e__124)))])),
+           (fun (i : 'e__124) (loc : Ploc.t) ->
               (Qast.Node ("TyLid", [Qast.Loc; i]) : 'ctyp)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop (Grammar.s_token ("", "_")),
@@ -5636,19 +5666,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (ident : 'ident Grammar.Entry.e)),
                        (fun (a : 'ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__122)));
+                          (Qast.VaVal a : 'e__123)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__122)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__123)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                           'e__122)))])),
-           (fun (i : 'e__122) _ (loc : Ploc.t) ->
+                           'e__123)))])),
+           (fun (i : 'e__123) _ (loc : Ploc.t) ->
               (Qast.Node ("TyQuo", [Qast.Loc; i]) : 'ctyp)))]];
     Grammar.extension
       (constructor_declaration : 'constructor_declaration Grammar.Entry.e)
@@ -5662,29 +5692,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__131)));
+                          (Qast.VaVal (Qast.Str a) : 'e__132)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__131)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__132)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__131)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__132)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_uid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_uid", loc, a) : 'e__131)));
+                          (Qast.VaAnt ("_uid", loc, a) : 'e__132)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "uid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                           'e__131)))])),
-           (fun (ci : 'e__131) (loc : Ploc.t) ->
+                           'e__132)))])),
+           (fun (ci : 'e__132) (loc : Ploc.t) ->
               (Qast.Tuple
                  [Qast.Loc; ci; Qast.VaVal (Qast.List []); Qast.Option None] :
                'constructor_declaration)));
@@ -5698,32 +5728,32 @@ Grammar.safe_extend
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("UIDENT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Str a) : 'e__130)));
+                                (Qast.VaVal (Qast.Str a) : 'e__131)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__130)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__131)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__130)));
+                                 'e__131)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_uid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_uid", loc, a) : 'e__130)));
+                                (Qast.VaAnt ("_uid", loc, a) : 'e__131)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "uid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                                 'e__130)))])))
+                                 'e__131)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (ci : 'e__130) (loc : Ploc.t) ->
+           (fun (t : 'ctyp) _ (ci : 'e__131) (loc : Ploc.t) ->
               (let (tl, rt) = generalized_type_of_type t in
                Qast.Tuple
                  [Qast.Loc; ci; Qast.VaVal tl; Qast.Option (Some rt)] :
@@ -5738,29 +5768,29 @@ Grammar.safe_extend
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("UIDENT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Str a) : 'e__128)));
+                                (Qast.VaVal (Qast.Str a) : 'e__129)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__128)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__129)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__128)));
+                                 'e__129)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_uid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_uid", loc, a) : 'e__128)));
+                                (Qast.VaAnt ("_uid", loc, a) : 'e__129)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "uid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("uid", loc, a)) :
-                                 'e__128)))])))
+                                 'e__129)))])))
                 (Grammar.s_token ("", "of")))
              (Grammar.s_facto
                 (Grammar.s_rules
@@ -5770,19 +5800,19 @@ Grammar.safe_extend
                             (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'ctyp list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__129)));
+                          (Qast.VaVal (Qast.List a) : 'e__130)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__129)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__130)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__129)))])),
-           (fun (cal : 'e__129) _ (ci : 'e__128) (loc : Ploc.t) ->
+                           'e__130)))])),
+           (fun (cal : 'e__130) _ (ci : 'e__129) (loc : Ploc.t) ->
               (Qast.Tuple [Qast.Loc; ci; cal; Qast.Option None] :
                'constructor_declaration)))]];
     Grammar.extension (label_declaration : 'label_declaration Grammar.Entry.e)
@@ -5861,19 +5891,19 @@ Grammar.safe_extend
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'class_type_declaration list)
                             (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__133)));
+                          (Qast.VaVal (Qast.List a) : 'e__134)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__133)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__134)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__133)))])),
-           (fun (ctd : 'e__133) _ _ (loc : Ploc.t) ->
+                           'e__134)))])),
+           (fun (ctd : 'e__134) _ _ (loc : Ploc.t) ->
               (Qast.Node ("StClt", [Qast.Loc; ctd]) : 'str_item)));
         Grammar.production
           (Grammar.r_next
@@ -5888,19 +5918,19 @@ Grammar.safe_extend
                                 'class_declaration Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'class_declaration list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__132)));
+                          (Qast.VaVal (Qast.List a) : 'e__133)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__132)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__133)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__132)))])),
-           (fun (cd : 'e__132) _ (loc : Ploc.t) ->
+                           'e__133)))])),
+           (fun (cd : 'e__133) _ (loc : Ploc.t) ->
               (Qast.Node ("StCls", [Qast.Loc; cd]) : 'str_item)))]];
     Grammar.extension (sig_item : 'sig_item Grammar.Entry.e) None
       [None, None,
@@ -5921,19 +5951,19 @@ Grammar.safe_extend
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'class_type_declaration list)
                             (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__135)));
+                          (Qast.VaVal (Qast.List a) : 'e__136)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__135)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__136)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__135)))])),
-           (fun (ctd : 'e__135) _ _ (loc : Ploc.t) ->
+                           'e__136)))])),
+           (fun (ctd : 'e__136) _ _ (loc : Ploc.t) ->
               (Qast.Node ("SgClt", [Qast.Loc; ctd]) : 'sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -5948,19 +5978,19 @@ Grammar.safe_extend
                                 'class_description Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'class_description list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__134)));
+                          (Qast.VaVal (Qast.List a) : 'e__135)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__134)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__135)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__134)))])),
-           (fun (cd : 'e__134) _ (loc : Ploc.t) ->
+                           'e__135)))])),
+           (fun (cd : 'e__135) _ (loc : Ploc.t) ->
               (Qast.Node ("SgCls", [Qast.Loc; cd]) : 'sig_item)))]];
     Grammar.extension (class_declaration : 'class_declaration Grammar.Entry.e)
       None
@@ -5977,65 +6007,65 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "virtual"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__136)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__137)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__136)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__137)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__136)));
+                                    'e__137)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__136)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__137)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__136)))])))
+                                    'e__137)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("LIDENT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Str a) : 'e__137)));
+                                (Qast.VaVal (Qast.Str a) : 'e__138)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__137)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__138)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__137)));
+                                 'e__138)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__137)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__138)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__137)))])))
+                                 'e__138)))])))
                 (Grammar.s_nterm
                    (class_type_parameters :
                     'class_type_parameters Grammar.Entry.e)))
              (Grammar.s_nterm
                 (class_fun_binding : 'class_fun_binding Grammar.Entry.e)),
            (fun (cfb : 'class_fun_binding) (ctp : 'class_type_parameters)
-                (i : 'e__137) (vf : 'e__136) (loc : Ploc.t) ->
+                (i : 'e__138) (vf : 'e__137) (loc : Ploc.t) ->
               (Qast.Record
                  ["ciLoc", Qast.Loc; "ciVir", vf; "ciPrm", ctp; "ciNam", i;
                   "ciExp", cfb] :
@@ -6086,20 +6116,20 @@ Grammar.safe_extend
                                    'type_parameter Grammar.Entry.e))
                                (Grammar.s_token ("", ",")) false),
                           (fun (a : 'type_parameter list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__138)));
+                             (Qast.VaVal (Qast.List a) : 'e__139)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__138)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__139)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__138)))])))
+                              'e__139)))])))
              (Grammar.s_token ("", "]")),
-           (fun _ (tpl : 'e__138) _ (loc : Ploc.t) ->
+           (fun _ (tpl : 'e__139) _ (loc : Ploc.t) ->
               (Qast.Tuple [Qast.Loc; tpl] : 'class_type_parameters)));
         Grammar.production
           (Grammar.r_stop,
@@ -6137,29 +6167,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "rec"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__139)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__140)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__139)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__140)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__139)));
+                                    'e__140)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__139)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__140)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__139)))])))
+                                    'e__140)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -6170,21 +6200,21 @@ Grammar.safe_extend
                                       'let_binding Grammar.Entry.e))
                                   (Grammar.s_token ("", "and")) false),
                              (fun (a : 'let_binding list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__140)));
+                                (Qast.VaVal (Qast.List a) : 'e__141)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__140)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__141)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__140)))])))
+                                 'e__141)))])))
                 (Grammar.s_token ("", "in")))
              Grammar.s_self,
-           (fun (ce : 'class_expr) _ (lb : 'e__140) (rf : 'e__139) _
+           (fun (ce : 'class_expr) _ (lb : 'e__141) (rf : 'e__140) _
                 (loc : Ploc.t) ->
               (Qast.Node ("CeLet", [Qast.Loc; rf; lb; ce]) : 'class_expr)));
         Grammar.production
@@ -6237,18 +6267,18 @@ Grammar.safe_extend
                                      (ctyp : 'ctyp Grammar.Entry.e))
                                   (Grammar.s_token ("", ",")) false),
                              (fun (a : 'ctyp list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__143)));
+                                (Qast.VaVal (Qast.List a) : 'e__144)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__143)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__144)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__143)))])))
+                                 'e__144)))])))
                 (Grammar.s_token ("", "]")))
              (Grammar.s_facto
                 (Grammar.s_rules
@@ -6258,19 +6288,19 @@ Grammar.safe_extend
                             (class_longident :
                              'class_longident Grammar.Entry.e)),
                        (fun (a : 'class_longident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__144)));
+                          (Qast.VaVal a : 'e__145)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__144)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__145)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__144)))])),
-           (fun (ci : 'e__144) _ (ctcl : 'e__143) _ (loc : Ploc.t) ->
+                           'e__145)))])),
+           (fun (ci : 'e__145) _ (ctcl : 'e__144) _ (loc : Ploc.t) ->
               (Qast.Node ("CeCon", [Qast.Loc; ci; ctcl]) : 'class_expr)));
         Grammar.production
           (Grammar.r_next
@@ -6288,22 +6318,22 @@ Grammar.safe_extend
                                       'class_self_patt Grammar.Entry.e))),
                              (fun (a : 'class_self_patt option)
                                   (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Option a) : 'e__142)));
+                                (Qast.VaVal (Qast.Option a) : 'e__143)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_opt")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_opt", loc, a) : 'e__142)));
+                                (Qast.VaAnt ("_opt", loc, a) : 'e__143)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "opt")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                 'e__142)))])))
+                                 'e__143)))])))
                 (Grammar.s_nterm
                    (class_structure : 'class_structure Grammar.Entry.e)))
              (Grammar.s_token ("", "end")),
-           (fun _ (cf : 'class_structure) (cspo : 'e__142) _ (loc : Ploc.t) ->
+           (fun _ (cf : 'class_structure) (cspo : 'e__143) _ (loc : Ploc.t) ->
               (Qast.Node ("CeStr", [Qast.Loc; cspo; cf]) : 'class_expr)));
         Grammar.production
           (Grammar.r_next Grammar.r_stop
@@ -6315,19 +6345,19 @@ Grammar.safe_extend
                             (class_longident :
                              'class_longident Grammar.Entry.e)),
                        (fun (a : 'class_longident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__141)));
+                          (Qast.VaVal a : 'e__142)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__141)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__142)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__141)))])),
-           (fun (ci : 'e__141) (loc : Ploc.t) ->
+                           'e__142)))])),
+           (fun (ci : 'e__142) (loc : Ploc.t) ->
               (Qast.Node
                  ("CeCon", [Qast.Loc; ci; Qast.VaVal (Qast.List [])]) :
                'class_expr)))]];
@@ -6351,21 +6381,21 @@ Grammar.safe_extend
                                      (Grammar.s_token ("", ";")),
                                    (fun _ (cf : 'class_str_item)
                                         (loc : Ploc.t) ->
-                                      (cf : 'e__145)))])),
-                       (fun (a : 'e__145 list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__146)));
+                                      (cf : 'e__146)))])),
+                       (fun (a : 'e__146 list) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.List a) : 'e__147)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__146)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__147)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__146)))])),
-           (fun (cf : 'e__146) (loc : Ploc.t) -> (cf : 'class_structure)))]];
+                           'e__147)))])),
+           (fun (cf : 'e__147) (loc : Ploc.t) -> (cf : 'class_structure)))]];
     Grammar.extension (class_self_patt : 'class_self_patt Grammar.Entry.e)
       None
       [None, None,
@@ -6424,18 +6454,18 @@ Grammar.safe_extend
                                      (Grammar.s_flag
                                         (Grammar.s_token ("", "!"))),
                                    (fun (a : bool) (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.Bool a) : 'e__157)));
+                                      (Qast.VaVal (Qast.Bool a) : 'e__158)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_!")),
                                    (fun (a : string) (loc : Ploc.t) ->
-                                      (Qast.VaAnt ("_!", loc, a) : 'e__157)));
+                                      (Qast.VaAnt ("_!", loc, a) : 'e__158)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "!")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal (Qast.VaAnt ("!", loc, a)) :
-                                       'e__157)))])))
+                                       'e__158)))])))
                       (Grammar.s_facto
                          (Grammar.s_rules
                             [Grammar.production
@@ -6443,18 +6473,18 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "private"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__158)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__159)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_priv")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_priv", loc, a) : 'e__158)));
+                                   (Qast.VaAnt ("_priv", loc, a) : 'e__159)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "priv")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("priv", loc, a)) :
-                                    'e__158)))])))
+                                    'e__159)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -6462,29 +6492,29 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (lident : 'lident Grammar.Entry.e)),
                              (fun (a : 'lident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__159)));
+                                (Qast.VaVal a : 'e__160)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__159)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__160)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__159)));
+                                 'e__160)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__159)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__160)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__159)))])))
+                                 'e__160)))])))
                 (Grammar.s_facto
                    (Grammar.s_rules
                       [Grammar.production
@@ -6493,21 +6523,21 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (polyt : 'polyt Grammar.Entry.e))),
                           (fun (a : 'polyt option) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Option a) : 'e__160)));
+                             (Qast.VaVal (Qast.Option a) : 'e__161)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__160)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__161)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__160)))])))
+                              'e__161)))])))
              (Grammar.s_nterm (fun_binding : 'fun_binding Grammar.Entry.e)),
-           (fun (e : 'fun_binding) (topt : 'e__160) (l : 'e__159)
-                (pf : 'e__158) (ovf : 'e__157) _ (loc : Ploc.t) ->
+           (fun (e : 'fun_binding) (topt : 'e__161) (l : 'e__160)
+                (pf : 'e__159) (ovf : 'e__158) _ (loc : Ploc.t) ->
               (Qast.Node ("CrMth", [Qast.Loc; ovf; pf; l; topt; e]) :
                'class_str_item)));
         Grammar.production
@@ -6526,29 +6556,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "private"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__155)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__156)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__155)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__156)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__155)));
+                                    'e__156)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__155)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__156)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__155)))])))
+                                    'e__156)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -6556,32 +6586,32 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (lident : 'lident Grammar.Entry.e)),
                              (fun (a : 'lident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__156)));
+                                (Qast.VaVal a : 'e__157)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__156)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__157)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__156)));
+                                 'e__157)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__156)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__157)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__156)))])))
+                                 'e__157)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (l : 'e__156) (pf : 'e__155) _ _
+           (fun (t : 'ctyp) _ (l : 'e__157) (pf : 'e__156) _ _
                 (loc : Ploc.t) ->
               (Qast.Node ("CrVir", [Qast.Loc; pf; l; t]) : 'class_str_item)));
         Grammar.production
@@ -6600,29 +6630,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "mutable"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__153)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__154)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__153)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__154)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__153)));
+                                    'e__154)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__153)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__154)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__153)))])))
+                                    'e__154)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -6630,32 +6660,32 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (lident : 'lident Grammar.Entry.e)),
                              (fun (a : 'lident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__154)));
+                                (Qast.VaVal a : 'e__155)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__154)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__155)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__154)));
+                                 'e__155)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__154)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__155)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__154)))])))
+                                 'e__155)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (lab : 'e__154) (mf : 'e__153) _ _
+           (fun (t : 'ctyp) _ (lab : 'e__155) (mf : 'e__154) _ _
                 (loc : Ploc.t) ->
               (Qast.Node ("CrVav", [Qast.Loc; mf; lab; t]) :
                'class_str_item)));
@@ -6673,18 +6703,18 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "!"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__150)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__151)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_!")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_!", loc, a) : 'e__150)));
+                                   (Qast.VaAnt ("_!", loc, a) : 'e__151)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "!")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("!", loc, a)) :
-                                    'e__150)))])))
+                                    'e__151)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -6692,29 +6722,29 @@ Grammar.safe_extend
                                (Grammar.s_flag
                                   (Grammar.s_token ("", "mutable"))),
                              (fun (a : bool) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Bool a) : 'e__151)));
+                                (Qast.VaVal (Qast.Bool a) : 'e__152)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_opt")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_opt", loc, a) : 'e__151)));
+                                (Qast.VaAnt ("_opt", loc, a) : 'e__152)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "opt")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                 'e__151)));
+                                 'e__152)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_flag")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_flag", loc, a) : 'e__151)));
+                                (Qast.VaAnt ("_flag", loc, a) : 'e__152)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "flag")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                 'e__151)))])))
+                                 'e__152)))])))
                 (Grammar.s_facto
                    (Grammar.s_rules
                       [Grammar.production
@@ -6722,33 +6752,33 @@ Grammar.safe_extend
                             (Grammar.s_nterm
                                (lident : 'lident Grammar.Entry.e)),
                           (fun (a : 'lident) (loc : Ploc.t) ->
-                             (Qast.VaVal a : 'e__152)));
+                             (Qast.VaVal a : 'e__153)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_", loc, a) : 'e__152)));
+                             (Qast.VaAnt ("_", loc, a) : 'e__153)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                              'e__152)));
+                              'e__153)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_lid")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_lid", loc, a) : 'e__152)));
+                             (Qast.VaAnt ("_lid", loc, a) : 'e__153)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "lid")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                              'e__152)))])))
+                              'e__153)))])))
              (Grammar.s_nterm
                 (cvalue_binding : 'cvalue_binding Grammar.Entry.e)),
-           (fun (e : 'cvalue_binding) (lab : 'e__152) (mf : 'e__151)
-                (ovf : 'e__150) _ (loc : Ploc.t) ->
+           (fun (e : 'cvalue_binding) (lab : 'e__153) (mf : 'e__152)
+                (ovf : 'e__151) _ (loc : Ploc.t) ->
               (Qast.Node ("CrVal", [Qast.Loc; ovf; mf; lab; e]) :
                'class_str_item)));
         Grammar.production
@@ -6765,19 +6795,19 @@ Grammar.safe_extend
                             (Grammar.s_nterm
                                (as_lident : 'as_lident Grammar.Entry.e))),
                        (fun (a : 'as_lident option) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Option a) : 'e__149)));
+                          (Qast.VaVal (Qast.Option a) : 'e__150)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_opt")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_opt", loc, a) : 'e__149)));
+                          (Qast.VaAnt ("_opt", loc, a) : 'e__150)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "opt")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                           'e__149)))])),
-           (fun (pb : 'e__149) (ce : 'class_expr) _ (loc : Ploc.t) ->
+                           'e__150)))])),
+           (fun (pb : 'e__150) (ce : 'class_expr) _ (loc : Ploc.t) ->
               (Qast.Node ("CrInh", [Qast.Loc; ce; pb]) : 'class_str_item)));
         Grammar.production
           (Grammar.r_next
@@ -6800,22 +6830,22 @@ Grammar.safe_extend
                                         (Grammar.s_token ("", ";")),
                                       (fun _ (s : 'class_str_item)
                                            (loc : Ploc.t) ->
-                                         (s : 'e__147)))])),
-                          (fun (a : 'e__147 list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__148)));
+                                         (s : 'e__148)))])),
+                          (fun (a : 'e__148 list) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.List a) : 'e__149)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__148)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__149)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__148)))])))
+                              'e__149)))])))
              (Grammar.s_token ("", "end")),
-           (fun _ (st : 'e__148) _ (loc : Ploc.t) ->
+           (fun _ (st : 'e__149) _ (loc : Ploc.t) ->
               (Qast.Node ("CrDcl", [Qast.Loc; st]) : 'class_str_item)))]];
     Grammar.extension (as_lident : 'as_lident Grammar.Entry.e) None
       [None, None,
@@ -6897,20 +6927,20 @@ Grammar.safe_extend
                                   (ctyp : 'ctyp Grammar.Entry.e))
                                (Grammar.s_token ("", ",")) false),
                           (fun (a : 'ctyp list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__164)));
+                             (Qast.VaVal (Qast.List a) : 'e__165)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__164)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__165)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__164)))])))
+                              'e__165)))])))
              (Grammar.s_token ("", "]")),
-           (fun _ (tl : 'e__164) _ (ct : 'class_type) (loc : Ploc.t) ->
+           (fun _ (tl : 'e__165) _ (ct : 'class_type) (loc : Ploc.t) ->
               (Qast.Node ("CtCon", [Qast.Loc; ct; tl]) : 'class_type)));
         Grammar.production
           (Grammar.r_next
@@ -6928,18 +6958,18 @@ Grammar.safe_extend
                                       'class_self_type Grammar.Entry.e))),
                              (fun (a : 'class_self_type option)
                                   (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Option a) : 'e__161)));
+                                (Qast.VaVal (Qast.Option a) : 'e__162)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_opt")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_opt", loc, a) : 'e__161)));
+                                (Qast.VaAnt ("_opt", loc, a) : 'e__162)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "opt")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                 'e__161)))])))
+                                 'e__162)))])))
                 (Grammar.s_facto
                    (Grammar.s_rules
                       [Grammar.production
@@ -6956,22 +6986,22 @@ Grammar.safe_extend
                                         (Grammar.s_token ("", ";")),
                                       (fun _ (csf : 'class_sig_item)
                                            (loc : Ploc.t) ->
-                                         (csf : 'e__162)))])),
-                          (fun (a : 'e__162 list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__163)));
+                                         (csf : 'e__163)))])),
+                          (fun (a : 'e__163 list) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.List a) : 'e__164)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__163)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__164)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__163)))])))
+                              'e__164)))])))
              (Grammar.s_token ("", "end")),
-           (fun _ (csf : 'e__163) (cst : 'e__161) _ (loc : Ploc.t) ->
+           (fun _ (csf : 'e__164) (cst : 'e__162) _ (loc : Ploc.t) ->
               (Qast.Node ("CtSig", [Qast.Loc; cst; csf]) : 'class_type)));
         Grammar.production
           (Grammar.r_next
@@ -7016,6 +7046,28 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("UIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Str a) : 'e__167)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "_id")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaAnt ("_id", loc, a) : 'e__167)));
+                    Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("ANTIQUOT", "id")),
+                       (fun (a : string) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.VaAnt ("id", loc, a)) :
+                           'e__167)))])),
+           (fun (i : 'e__167) (loc : Ploc.t) ->
+              (Qast.Node ("CtIde", [Qast.Loc; i]) : 'class_type)));
+        Grammar.production
+          (Grammar.r_next Grammar.r_stop
+             (Grammar.s_facto
+                (Grammar.s_rules
+                   [Grammar.production
+                      (Grammar.r_next Grammar.r_stop
+                         (Grammar.s_token ("LIDENT", "")),
+                       (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.Str a) : 'e__166)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
@@ -7029,28 +7081,6 @@ Grammar.safe_extend
                           (Qast.VaVal (Qast.VaAnt ("id", loc, a)) :
                            'e__166)))])),
            (fun (i : 'e__166) (loc : Ploc.t) ->
-              (Qast.Node ("CtIde", [Qast.Loc; i]) : 'class_type)));
-        Grammar.production
-          (Grammar.r_next Grammar.r_stop
-             (Grammar.s_facto
-                (Grammar.s_rules
-                   [Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("LIDENT", "")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__165)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "_id")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_id", loc, a) : 'e__165)));
-                    Grammar.production
-                      (Grammar.r_next Grammar.r_stop
-                         (Grammar.s_token ("ANTIQUOT", "id")),
-                       (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("id", loc, a)) :
-                           'e__165)))])),
-           (fun (i : 'e__165) (loc : Ploc.t) ->
               (Qast.Node ("CtIde", [Qast.Loc; i]) : 'class_type)))]];
     Grammar.extension (class_self_type : 'class_self_type Grammar.Entry.e)
       None
@@ -7089,29 +7119,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "private"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__173)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__174)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__173)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__174)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__173)));
+                                    'e__174)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__173)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__174)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__173)))])))
+                                    'e__174)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -7119,32 +7149,32 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (lident : 'lident Grammar.Entry.e)),
                              (fun (a : 'lident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__174)));
+                                (Qast.VaVal a : 'e__175)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__174)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__175)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__174)));
+                                 'e__175)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__174)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__175)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__174)))])))
+                                 'e__175)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (l : 'e__174) (pf : 'e__173) _ (loc : Ploc.t) ->
+           (fun (t : 'ctyp) _ (l : 'e__175) (pf : 'e__174) _ (loc : Ploc.t) ->
               (Qast.Node ("CgMth", [Qast.Loc; pf; l; t]) : 'class_sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -7162,29 +7192,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "private"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__171)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__172)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__171)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__172)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__171)));
+                                    'e__172)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__171)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__172)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__171)))])))
+                                    'e__172)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -7192,32 +7222,32 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (lident : 'lident Grammar.Entry.e)),
                              (fun (a : 'lident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__172)));
+                                (Qast.VaVal a : 'e__173)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__172)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__173)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__172)));
+                                 'e__173)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__172)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__173)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__172)))])))
+                                 'e__173)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (l : 'e__172) (pf : 'e__171) _ _
+           (fun (t : 'ctyp) _ (l : 'e__173) (pf : 'e__172) _ _
                 (loc : Ploc.t) ->
               (Qast.Node ("CgVir", [Qast.Loc; pf; l; t]) : 'class_sig_item)));
         Grammar.production
@@ -7234,29 +7264,29 @@ Grammar.safe_extend
                                   (Grammar.s_flag
                                      (Grammar.s_token ("", "mutable"))),
                                 (fun (a : bool) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Bool a) : 'e__169)));
+                                   (Qast.VaVal (Qast.Bool a) : 'e__170)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_opt", loc, a) : 'e__169)));
+                                   (Qast.VaAnt ("_opt", loc, a) : 'e__170)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "opt")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                    'e__169)));
+                                    'e__170)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_flag", loc, a) : 'e__169)));
+                                   (Qast.VaAnt ("_flag", loc, a) : 'e__170)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "flag")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                                    'e__169)))])))
+                                    'e__170)))])))
                    (Grammar.s_facto
                       (Grammar.s_rules
                          [Grammar.production
@@ -7264,32 +7294,32 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (lident : 'lident Grammar.Entry.e)),
                              (fun (a : 'lident) (loc : Ploc.t) ->
-                                (Qast.VaVal a : 'e__170)));
+                                (Qast.VaVal a : 'e__171)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_", loc, a) : 'e__170)));
+                                (Qast.VaAnt ("_", loc, a) : 'e__171)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                 'e__170)));
+                                 'e__171)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_lid")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_lid", loc, a) : 'e__170)));
+                                (Qast.VaAnt ("_lid", loc, a) : 'e__171)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "lid")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                 'e__170)))])))
+                                 'e__171)))])))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)),
-           (fun (t : 'ctyp) _ (l : 'e__170) (mf : 'e__169) _ (loc : Ploc.t) ->
+           (fun (t : 'ctyp) _ (l : 'e__171) (mf : 'e__170) _ (loc : Ploc.t) ->
               (Qast.Node ("CgVal", [Qast.Loc; mf; l; t]) : 'class_sig_item)));
         Grammar.production
           (Grammar.r_next
@@ -7318,22 +7348,22 @@ Grammar.safe_extend
                                         (Grammar.s_token ("", ";")),
                                       (fun _ (s : 'class_sig_item)
                                            (loc : Ploc.t) ->
-                                         (s : 'e__167)))])),
-                          (fun (a : 'e__167 list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__168)));
+                                         (s : 'e__168)))])),
+                          (fun (a : 'e__168 list) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.List a) : 'e__169)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__168)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__169)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__168)))])))
+                              'e__169)))])))
              (Grammar.s_token ("", "end")),
-           (fun _ (st : 'e__168) _ (loc : Ploc.t) ->
+           (fun _ (st : 'e__169) _ (loc : Ploc.t) ->
               (Qast.Node ("CgDcl", [Qast.Loc; st]) : 'class_sig_item)))]];
     Grammar.extension (class_description : 'class_description Grammar.Entry.e)
       None
@@ -7351,69 +7381,69 @@ Grammar.safe_extend
                                      (Grammar.s_flag
                                         (Grammar.s_token ("", "virtual"))),
                                    (fun (a : bool) (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.Bool a) : 'e__175)));
+                                      (Qast.VaVal (Qast.Bool a) : 'e__176)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_opt")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_opt", loc, a) :
-                                       'e__175)));
+                                       'e__176)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "opt")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("opt", loc, a)) :
-                                       'e__175)));
+                                       'e__176)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_flag")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_flag", loc, a) :
-                                       'e__175)));
+                                       'e__176)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "flag")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("flag", loc, a)) :
-                                       'e__175)))])))
+                                       'e__176)))])))
                       (Grammar.s_facto
                          (Grammar.s_rules
                             [Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("LIDENT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__176)));
+                                   (Qast.VaVal (Qast.Str a) : 'e__177)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__176)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__177)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__176)));
+                                    'e__177)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_lid", loc, a) : 'e__176)));
+                                   (Qast.VaAnt ("_lid", loc, a) : 'e__177)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                    'e__176)))])))
+                                    'e__177)))])))
                    (Grammar.s_nterm
                       (class_type_parameters :
                        'class_type_parameters Grammar.Entry.e)))
                 (Grammar.s_token ("", ":")))
              (Grammar.s_nterm (class_type : 'class_type Grammar.Entry.e)),
            (fun (ct : 'class_type) _ (ctp : 'class_type_parameters)
-                (n : 'e__176) (vf : 'e__175) (loc : Ploc.t) ->
+                (n : 'e__177) (vf : 'e__176) (loc : Ploc.t) ->
               (Qast.Record
                  ["ciLoc", Qast.Loc; "ciVir", vf; "ciPrm", ctp; "ciNam", n;
                   "ciExp", ct] :
@@ -7434,69 +7464,69 @@ Grammar.safe_extend
                                      (Grammar.s_flag
                                         (Grammar.s_token ("", "virtual"))),
                                    (fun (a : bool) (loc : Ploc.t) ->
-                                      (Qast.VaVal (Qast.Bool a) : 'e__177)));
+                                      (Qast.VaVal (Qast.Bool a) : 'e__178)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_opt")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_opt", loc, a) :
-                                       'e__177)));
+                                       'e__178)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "opt")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("opt", loc, a)) :
-                                       'e__177)));
+                                       'e__178)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "_flag")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaAnt ("_flag", loc, a) :
-                                       'e__177)));
+                                       'e__178)));
                                 Grammar.production
                                   (Grammar.r_next Grammar.r_stop
                                      (Grammar.s_token ("ANTIQUOT", "flag")),
                                    (fun (a : string) (loc : Ploc.t) ->
                                       (Qast.VaVal
                                          (Qast.VaAnt ("flag", loc, a)) :
-                                       'e__177)))])))
+                                       'e__178)))])))
                       (Grammar.s_facto
                          (Grammar.s_rules
                             [Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("LIDENT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__178)));
+                                   (Qast.VaVal (Qast.Str a) : 'e__179)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__178)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__179)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__178)));
+                                    'e__179)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_lid", loc, a) : 'e__178)));
+                                   (Qast.VaAnt ("_lid", loc, a) : 'e__179)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                    'e__178)))])))
+                                    'e__179)))])))
                    (Grammar.s_nterm
                       (class_type_parameters :
                        'class_type_parameters Grammar.Entry.e)))
                 (Grammar.s_token ("", "=")))
              (Grammar.s_nterm (class_type : 'class_type Grammar.Entry.e)),
            (fun (cs : 'class_type) _ (ctp : 'class_type_parameters)
-                (n : 'e__178) (vf : 'e__177) (loc : Ploc.t) ->
+                (n : 'e__179) (vf : 'e__178) (loc : Ploc.t) ->
               (Qast.Record
                  ["ciLoc", Qast.Loc; "ciVir", vf; "ciPrm", ctp; "ciNam", n;
                   "ciExp", cs] :
@@ -7520,22 +7550,22 @@ Grammar.safe_extend
                                       'class_self_patt Grammar.Entry.e))),
                              (fun (a : 'class_self_patt option)
                                   (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Option a) : 'e__180)));
+                                (Qast.VaVal (Qast.Option a) : 'e__181)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_opt")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_opt", loc, a) : 'e__180)));
+                                (Qast.VaAnt ("_opt", loc, a) : 'e__181)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "opt")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                 'e__180)))])))
+                                 'e__181)))])))
                 (Grammar.s_nterm
                    (class_structure : 'class_structure Grammar.Entry.e)))
              (Grammar.s_token ("", "end")),
-           (fun _ (cf : 'class_structure) (cspo : 'e__180) _ (loc : Ploc.t) ->
+           (fun _ (cf : 'class_structure) (cspo : 'e__181) _ (loc : Ploc.t) ->
               (Qast.Node ("ExObj", [Qast.Loc; cspo; cf]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -7548,19 +7578,19 @@ Grammar.safe_extend
                             (class_longident :
                              'class_longident Grammar.Entry.e)),
                        (fun (a : 'class_longident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__179)));
+                          (Qast.VaVal a : 'e__180)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__179)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__180)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__179)))])),
-           (fun (i : 'e__179) _ (loc : Ploc.t) ->
+                           'e__180)))])),
+           (fun (i : 'e__180) _ (loc : Ploc.t) ->
               (Qast.Node ("ExNew", [Qast.Loc; i]) : 'expr)))]];
     Grammar.extension (expr : 'expr Grammar.Entry.e)
       (Some (Gramext.Level "."))
@@ -7575,29 +7605,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (lident : 'lident Grammar.Entry.e)),
                        (fun (a : 'lident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__181)));
+                          (Qast.VaVal a : 'e__182)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__181)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__182)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__181)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__182)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__181)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__182)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__181)))])),
-           (fun (lab : 'e__181) _ (e : 'expr) (loc : Ploc.t) ->
+                           'e__182)))])),
+           (fun (lab : 'e__182) _ (e : 'expr) (loc : Ploc.t) ->
               (Qast.Node ("ExSnd", [Qast.Loc; e; lab]) : 'expr)))]];
     Grammar.extension (expr : 'expr Grammar.Entry.e)
       (Some (Gramext.Level "simple"))
@@ -7615,20 +7645,20 @@ Grammar.safe_extend
                                   (field_expr : 'field_expr Grammar.Entry.e))
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'field_expr list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__182)));
+                             (Qast.VaVal (Qast.List a) : 'e__183)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__182)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__183)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__182)))])))
+                              'e__183)))])))
              (Grammar.s_token ("", ">}")),
-           (fun _ (fel : 'e__182) _ (loc : Ploc.t) ->
+           (fun _ (fel : 'e__183) _ (loc : Ploc.t) ->
               (Qast.Node ("ExOvr", [Qast.Loc; fel]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -7690,49 +7720,49 @@ Grammar.safe_extend
                                      (field : 'field Grammar.Entry.e))
                                   (Grammar.s_token ("", ";")) false),
                              (fun (a : 'field list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__184)));
+                                (Qast.VaVal (Qast.List a) : 'e__185)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__184)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__185)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__184)))])))
+                                 'e__185)))])))
                 (Grammar.s_facto
                    (Grammar.s_rules
                       [Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_flag (Grammar.s_token ("", ".."))),
                           (fun (a : bool) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Bool a) : 'e__185)));
+                             (Qast.VaVal (Qast.Bool a) : 'e__186)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__185)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__186)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__185)));
+                              'e__186)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_flag")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_flag", loc, a) : 'e__185)));
+                             (Qast.VaAnt ("_flag", loc, a) : 'e__186)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "flag")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                              'e__185)))])))
+                              'e__186)))])))
              (Grammar.s_token ("", ">")),
-           (fun _ (v : 'e__185) (ml : 'e__184) _ (loc : Ploc.t) ->
+           (fun _ (v : 'e__186) (ml : 'e__185) _ (loc : Ploc.t) ->
               (Qast.Node ("TyObj", [Qast.Loc; ml; v]) : 'ctyp)));
         Grammar.production
           (Grammar.r_next
@@ -7745,19 +7775,19 @@ Grammar.safe_extend
                             (class_longident :
                              'class_longident Grammar.Entry.e)),
                        (fun (a : 'class_longident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__183)));
+                          (Qast.VaVal a : 'e__184)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__183)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__184)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__183)))])),
-           (fun (id : 'e__183) _ (loc : Ploc.t) ->
+                           'e__184)))])),
+           (fun (id : 'e__184) _ (loc : Ploc.t) ->
               (Qast.Node ("TyCls", [Qast.Loc; id]) : 'ctyp)))]];
     Grammar.extension (field : 'field Grammar.Entry.e) None
       [None, None,
@@ -7799,25 +7829,25 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_nterm
                                (a_qic : 'a_qic Grammar.Entry.e)),
-                          (fun (a : 'a_qic) (loc : Ploc.t) -> (a : 'e__187)));
+                          (fun (a : 'a_qic) (loc : Ploc.t) -> (a : 'e__188)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("QUESTIONIDENTCOLON", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__187)));
+                             (Qast.VaVal (Qast.Str a) : 'e__188)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "?_:")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("?_:", loc, a) : 'e__187)));
+                             (Qast.VaAnt ("?_:", loc, a) : 'e__188)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "?:")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("?:", loc, a)) :
-                              'e__187)))])))
+                              'e__188)))])))
              Grammar.s_self,
-           (fun (t : 'ctyp) (i : 'e__187) (loc : Ploc.t) ->
+           (fun (t : 'ctyp) (i : 'e__188) (loc : Ploc.t) ->
               (Qast.Node ("TyOlb", [Qast.Loc; i; t]) : 'ctyp)));
         Grammar.production
           (Grammar.r_next
@@ -7828,25 +7858,25 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_nterm
                                (a_tic : 'a_tic Grammar.Entry.e)),
-                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__186)));
+                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__187)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("TILDEIDENTCOLON", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__186)));
+                             (Qast.VaVal (Qast.Str a) : 'e__187)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~_:")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("~_:", loc, a) : 'e__186)));
+                             (Qast.VaAnt ("~_:", loc, a) : 'e__187)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~:")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("~:", loc, a)) :
-                              'e__186)))])))
+                              'e__187)))])))
              Grammar.s_self,
-           (fun (t : 'ctyp) (i : 'e__186) (loc : Ploc.t) ->
+           (fun (t : 'ctyp) (i : 'e__187) (loc : Ploc.t) ->
               (Qast.Node ("TyLab", [Qast.Loc; i; t]) : 'ctyp)))]];
     Grammar.extension (ctyp : 'ctyp Grammar.Entry.e)
       (Some (Gramext.Level "simple"))
@@ -7872,20 +7902,20 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (name_tag : 'name_tag Grammar.Entry.e))),
                           (fun (a : 'name_tag list) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__188)));
+                             (Qast.VaVal (Qast.List a) : 'e__189)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__188)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__189)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__188)))])))
+                              'e__189)))])))
              (Grammar.s_token ("", "]")),
-           (fun _ (ntl : 'e__188) _ (rfl : 'poly_variant_list) _ _
+           (fun _ (ntl : 'e__189) _ (rfl : 'poly_variant_list) _ _
                 (loc : Ploc.t) ->
               (Qast.Node
                  ("TyVrn",
@@ -7949,19 +7979,19 @@ Grammar.safe_extend
                                (poly_variant : 'poly_variant Grammar.Entry.e))
                             (Grammar.s_token ("", "|")) false),
                        (fun (a : 'poly_variant list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__189)));
+                          (Qast.VaVal (Qast.List a) : 'e__190)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__189)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__190)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__189)))])),
-           (fun (rfl : 'e__189) (loc : Ploc.t) ->
+                           'e__190)))])),
+           (fun (rfl : 'e__190) (loc : Ploc.t) ->
               (rfl : 'poly_variant_list)))]];
     Grammar.extension (poly_variant : 'poly_variant Grammar.Entry.e) None
       [None, None,
@@ -7984,18 +8014,18 @@ Grammar.safe_extend
                                   (Grammar.s_nterm
                                      (ident : 'ident Grammar.Entry.e)),
                                 (fun (a : 'ident) (loc : Ploc.t) ->
-                                   (Qast.VaVal a : 'e__191)));
+                                   (Qast.VaVal a : 'e__192)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__191)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__192)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__191)))])))
+                                    'e__192)))])))
                    (Grammar.s_token ("", "of")))
                 (Grammar.s_facto
                    (Grammar.s_rules
@@ -8003,29 +8033,29 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_flag (Grammar.s_token ("", "&"))),
                           (fun (a : bool) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Bool a) : 'e__192)));
+                             (Qast.VaVal (Qast.Bool a) : 'e__193)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__192)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__193)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__192)));
+                              'e__193)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_flag")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_flag", loc, a) : 'e__192)));
+                             (Qast.VaAnt ("_flag", loc, a) : 'e__193)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "flag")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("flag", loc, a)) :
-                              'e__192)))])))
+                              'e__193)))])))
              (Grammar.s_facto
                 (Grammar.s_rules
                    [Grammar.production
@@ -8034,19 +8064,19 @@ Grammar.safe_extend
                             (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e))
                             (Grammar.s_token ("", "&")) false),
                        (fun (a : 'ctyp list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__193)));
+                          (Qast.VaVal (Qast.List a) : 'e__194)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__193)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__194)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__193)))])),
-           (fun (l : 'e__193) (ao : 'e__192) _ (i : 'e__191) _
+                           'e__194)))])),
+           (fun (l : 'e__194) (ao : 'e__193) _ (i : 'e__192) _
                 (loc : Ploc.t) ->
               (Qast.Node ("PvTag", [Qast.Loc; i; ao; l]) : 'poly_variant)));
         Grammar.production
@@ -8058,19 +8088,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (ident : 'ident Grammar.Entry.e)),
                        (fun (a : 'ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__190)));
+                          (Qast.VaVal a : 'e__191)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__190)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__191)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                           'e__190)))])),
-           (fun (i : 'e__190) _ (loc : Ploc.t) ->
+                           'e__191)))])),
+           (fun (i : 'e__191) _ (loc : Ploc.t) ->
               (Qast.Node
                  ("PvTag",
                   [Qast.Loc; i; Qast.VaVal (Qast.Bool true);
@@ -8099,24 +8129,24 @@ Grammar.safe_extend
                    [Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (a_ti : 'a_ti Grammar.Entry.e)),
-                       (fun (a : 'a_ti) (loc : Ploc.t) -> (a : 'e__200)));
+                       (fun (a : 'a_ti) (loc : Ploc.t) -> (a : 'e__201)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("TILDEIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__200)));
+                          (Qast.VaVal (Qast.Str a) : 'e__201)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "~_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("~_", loc, a) : 'e__200)));
+                          (Qast.VaAnt ("~_", loc, a) : 'e__201)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "~")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("~", loc, a)) :
-                           'e__200)))])),
-           (fun (i : 'e__200) (loc : Ploc.t) ->
+                           'e__201)))])),
+           (fun (i : 'e__201) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("PaLab",
@@ -8136,25 +8166,25 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_nterm
                                (a_tic : 'a_tic Grammar.Entry.e)),
-                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__199)));
+                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__200)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("TILDEIDENTCOLON", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__199)));
+                             (Qast.VaVal (Qast.Str a) : 'e__200)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~_:")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("~_:", loc, a) : 'e__199)));
+                             (Qast.VaAnt ("~_:", loc, a) : 'e__200)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~:")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("~:", loc, a)) :
-                              'e__199)))])))
+                              'e__200)))])))
              Grammar.s_self,
-           (fun (p : 'patt) (i : 'e__199) (loc : Ploc.t) ->
+           (fun (p : 'patt) (i : 'e__200) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("PaLab",
@@ -8187,22 +8217,22 @@ Grammar.safe_extend
                                         (Grammar.s_nterm
                                            (expr : 'expr Grammar.Entry.e)),
                                       (fun (e : 'expr) _ (loc : Ploc.t) ->
-                                         (e : 'e__197)))])),
-                          (fun (a : 'e__197 option) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Option a) : 'e__198)));
+                                         (e : 'e__198)))])),
+                          (fun (a : 'e__198 option) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.Option a) : 'e__199)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__198)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__199)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__198)))])))
+                              'e__199)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (eo : 'e__198) (p : 'patt_tcon) _ _ (loc : Ploc.t) ->
+           (fun _ (eo : 'e__199) (p : 'patt_tcon) _ _ (loc : Ploc.t) ->
               (Qast.Node ("PaOlb", [Qast.Loc; p; eo]) : 'patt)));
         Grammar.production
           (Grammar.r_next
@@ -8221,20 +8251,20 @@ Grammar.safe_extend
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'patt_tcon_opt_eq_patt list)
                                (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__196)));
+                             (Qast.VaVal (Qast.List a) : 'e__197)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__196)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__197)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__196)))])))
+                              'e__197)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (lppo : 'e__196) _ _ (loc : Ploc.t) ->
+           (fun _ (lppo : 'e__197) _ _ (loc : Ploc.t) ->
               (Qast.Node ("PaLab", [Qast.Loc; lppo]) : 'patt)));
         Grammar.production
           (Grammar.r_next
@@ -8246,29 +8276,29 @@ Grammar.safe_extend
                          (Grammar.s_nterm
                             (mod_ident : 'mod_ident Grammar.Entry.e)),
                        (fun (a : 'mod_ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__195)));
+                          (Qast.VaVal a : 'e__196)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__195)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__196)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__195)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__196)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__195)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__196)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__195)))])),
-           (fun (sl : 'e__195) _ (loc : Ploc.t) ->
+                           'e__196)))])),
+           (fun (sl : 'e__196) _ (loc : Ploc.t) ->
               (Qast.Node ("PaTyp", [Qast.Loc; sl]) : 'patt)));
         Grammar.production
           (Grammar.r_next
@@ -8279,19 +8309,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (ident : 'ident Grammar.Entry.e)),
                        (fun (a : 'ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__194)));
+                          (Qast.VaVal a : 'e__195)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__194)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__195)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                           'e__194)))])),
-           (fun (s : 'e__194) _ (loc : Ploc.t) ->
+                           'e__195)))])),
+           (fun (s : 'e__195) _ (loc : Ploc.t) ->
               (Qast.Node ("PaVrn", [Qast.Loc; s]) : 'patt)))]];
     Grammar.extension
       (patt_tcon_opt_eq_patt : 'patt_tcon_opt_eq_patt Grammar.Entry.e) None
@@ -8313,21 +8343,21 @@ Grammar.safe_extend
                                      (Grammar.s_nterm
                                         (patt : 'patt Grammar.Entry.e)),
                                    (fun (p : 'patt) _ (loc : Ploc.t) ->
-                                      (p : 'e__201)))])),
-                       (fun (a : 'e__201 option) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Option a) : 'e__202)));
+                                      (p : 'e__202)))])),
+                       (fun (a : 'e__202 option) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Option a) : 'e__203)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_opt")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_opt", loc, a) : 'e__202)));
+                          (Qast.VaAnt ("_opt", loc, a) : 'e__203)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "opt")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                           'e__202)))])),
-           (fun (po : 'e__202) (p : 'patt_tcon) (loc : Ploc.t) ->
+                           'e__203)))])),
+           (fun (po : 'e__203) (p : 'patt_tcon) (loc : Ploc.t) ->
               (Qast.Tuple [p; po] : 'patt_tcon_opt_eq_patt)))]];
     Grammar.extension (patt_tcon : 'patt_tcon Grammar.Entry.e) None
       [None, None,
@@ -8359,24 +8389,24 @@ Grammar.safe_extend
                    [Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (a_ti : 'a_ti Grammar.Entry.e)),
-                       (fun (a : 'a_ti) (loc : Ploc.t) -> (a : 'e__207)));
+                       (fun (a : 'a_ti) (loc : Ploc.t) -> (a : 'e__208)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("TILDEIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__207)));
+                          (Qast.VaVal (Qast.Str a) : 'e__208)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "~_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("~_", loc, a) : 'e__207)));
+                          (Qast.VaAnt ("~_", loc, a) : 'e__208)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "~")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("~", loc, a)) :
-                           'e__207)))])),
-           (fun (i : 'e__207) (loc : Ploc.t) ->
+                           'e__208)))])),
+           (fun (i : 'e__208) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("PaLab",
@@ -8396,25 +8426,25 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_nterm
                                (a_tic : 'a_tic Grammar.Entry.e)),
-                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__206)));
+                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__207)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("TILDEIDENTCOLON", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__206)));
+                             (Qast.VaVal (Qast.Str a) : 'e__207)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~_:")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("~_:", loc, a) : 'e__206)));
+                             (Qast.VaAnt ("~_:", loc, a) : 'e__207)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~:")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("~:", loc, a)) :
-                              'e__206)))])))
+                              'e__207)))])))
              Grammar.s_self,
-           (fun (p : 'ipatt) (i : 'e__206) (loc : Ploc.t) ->
+           (fun (p : 'ipatt) (i : 'e__207) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("PaLab",
@@ -8448,22 +8478,22 @@ Grammar.safe_extend
                                         (Grammar.s_nterm
                                            (expr : 'expr Grammar.Entry.e)),
                                       (fun (e : 'expr) _ (loc : Ploc.t) ->
-                                         (e : 'e__204)))])),
-                          (fun (a : 'e__204 option) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Option a) : 'e__205)));
+                                         (e : 'e__205)))])),
+                          (fun (a : 'e__205 option) (loc : Ploc.t) ->
+                             (Qast.VaVal (Qast.Option a) : 'e__206)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__205)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__206)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__205)))])))
+                              'e__206)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (eo : 'e__205) (p : 'ipatt_tcon) _ _ (loc : Ploc.t) ->
+           (fun _ (eo : 'e__206) (p : 'ipatt_tcon) _ _ (loc : Ploc.t) ->
               (Qast.Node ("PaOlb", [Qast.Loc; p; eo]) : 'ipatt)));
         Grammar.production
           (Grammar.r_next
@@ -8482,20 +8512,20 @@ Grammar.safe_extend
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'ipatt_tcon_opt_eq_patt list)
                                (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__203)));
+                             (Qast.VaVal (Qast.List a) : 'e__204)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__203)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__204)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__203)))])))
+                              'e__204)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (lppo : 'e__203) _ _ (loc : Ploc.t) ->
+           (fun _ (lppo : 'e__204) _ _ (loc : Ploc.t) ->
               (Qast.Node ("PaLab", [Qast.Loc; lppo]) : 'ipatt)))]];
     Grammar.extension
       (ipatt_tcon_opt_eq_patt : 'ipatt_tcon_opt_eq_patt Grammar.Entry.e) None
@@ -8517,21 +8547,21 @@ Grammar.safe_extend
                                      (Grammar.s_nterm
                                         (patt : 'patt Grammar.Entry.e)),
                                    (fun (p : 'patt) _ (loc : Ploc.t) ->
-                                      (p : 'e__208)))])),
-                       (fun (a : 'e__208 option) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Option a) : 'e__209)));
+                                      (p : 'e__209)))])),
+                       (fun (a : 'e__209 option) (loc : Ploc.t) ->
+                          (Qast.VaVal (Qast.Option a) : 'e__210)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_opt")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_opt", loc, a) : 'e__209)));
+                          (Qast.VaAnt ("_opt", loc, a) : 'e__210)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "opt")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                           'e__209)))])),
-           (fun (po : 'e__209) (p : 'ipatt_tcon) (loc : Ploc.t) ->
+                           'e__210)))])),
+           (fun (po : 'e__210) (p : 'ipatt_tcon) (loc : Ploc.t) ->
               (Qast.Tuple [p; po] : 'ipatt_tcon_opt_eq_patt)))]];
     Grammar.extension (ipatt_tcon : 'ipatt_tcon Grammar.Entry.e) None
       [None, None,
@@ -8563,35 +8593,82 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("LIDENT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__222)));
+                             (Qast.VaVal (Qast.Str a) : 'e__223)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_", loc, a) : 'e__222)));
+                             (Qast.VaAnt ("_", loc, a) : 'e__223)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                              'e__222)));
+                              'e__223)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_lid")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_lid", loc, a) : 'e__222)));
+                             (Qast.VaAnt ("_lid", loc, a) : 'e__223)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "lid")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                              'e__222)))])))
+                              'e__223)))])))
              (Grammar.s_token ("", ")")),
-           (fun _ (i : 'e__222) _ _ (loc : Ploc.t) ->
+           (fun _ (i : 'e__223) _ _ (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
                   [Qast.Loc; Qast.Node ("PaLid", [Qast.Loc; i]);
                    Qast.VaVal (Qast.Option None)]) :
+               'patt_option_label)));
+        Grammar.production
+          (Grammar.r_next
+             (Grammar.r_next
+                (Grammar.r_next
+                   (Grammar.r_next
+                      (Grammar.r_next
+                         (Grammar.r_next Grammar.r_stop
+                            (Grammar.s_token ("", "?")))
+                         (Grammar.s_token ("", "(")))
+                      (Grammar.s_facto
+                         (Grammar.s_rules
+                            [Grammar.production
+                               (Grammar.r_next Grammar.r_stop
+                                  (Grammar.s_token ("LIDENT", "")),
+                                (fun (a : string) (loc : Ploc.t) ->
+                                   (Qast.VaVal (Qast.Str a) : 'e__222)));
+                             Grammar.production
+                               (Grammar.r_next Grammar.r_stop
+                                  (Grammar.s_token ("ANTIQUOT", "_")),
+                                (fun (a : string) (loc : Ploc.t) ->
+                                   (Qast.VaAnt ("_", loc, a) : 'e__222)));
+                             Grammar.production
+                               (Grammar.r_next Grammar.r_stop
+                                  (Grammar.s_token ("ANTIQUOT", "")),
+                                (fun (a : string) (loc : Ploc.t) ->
+                                   (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
+                                    'e__222)));
+                             Grammar.production
+                               (Grammar.r_next Grammar.r_stop
+                                  (Grammar.s_token ("ANTIQUOT", "_lid")),
+                                (fun (a : string) (loc : Ploc.t) ->
+                                   (Qast.VaAnt ("_lid", loc, a) : 'e__222)));
+                             Grammar.production
+                               (Grammar.r_next Grammar.r_stop
+                                  (Grammar.s_token ("ANTIQUOT", "lid")),
+                                (fun (a : string) (loc : Ploc.t) ->
+                                   (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
+                                    'e__222)))])))
+                   (Grammar.s_token ("", "=")))
+                (Grammar.s_nterm (expr : 'expr Grammar.Entry.e)))
+             (Grammar.s_token ("", ")")),
+           (fun _ (e : 'expr) _ (i : 'e__222) _ _ (loc : Ploc.t) ->
+              (Qast.Node
+                 ("PaOlb",
+                  [Qast.Loc; Qast.Node ("PaLid", [Qast.Loc; i]);
+                   Qast.VaVal (Qast.Option (Some e))]) :
                'patt_option_label)));
         Grammar.production
           (Grammar.r_next
@@ -8631,57 +8708,10 @@ Grammar.safe_extend
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
                                     'e__221)))])))
-                   (Grammar.s_token ("", "=")))
-                (Grammar.s_nterm (expr : 'expr Grammar.Entry.e)))
-             (Grammar.s_token ("", ")")),
-           (fun _ (e : 'expr) _ (i : 'e__221) _ _ (loc : Ploc.t) ->
-              (Qast.Node
-                 ("PaOlb",
-                  [Qast.Loc; Qast.Node ("PaLid", [Qast.Loc; i]);
-                   Qast.VaVal (Qast.Option (Some e))]) :
-               'patt_option_label)));
-        Grammar.production
-          (Grammar.r_next
-             (Grammar.r_next
-                (Grammar.r_next
-                   (Grammar.r_next
-                      (Grammar.r_next
-                         (Grammar.r_next Grammar.r_stop
-                            (Grammar.s_token ("", "?")))
-                         (Grammar.s_token ("", "(")))
-                      (Grammar.s_facto
-                         (Grammar.s_rules
-                            [Grammar.production
-                               (Grammar.r_next Grammar.r_stop
-                                  (Grammar.s_token ("LIDENT", "")),
-                                (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__220)));
-                             Grammar.production
-                               (Grammar.r_next Grammar.r_stop
-                                  (Grammar.s_token ("ANTIQUOT", "_")),
-                                (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__220)));
-                             Grammar.production
-                               (Grammar.r_next Grammar.r_stop
-                                  (Grammar.s_token ("ANTIQUOT", "")),
-                                (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__220)));
-                             Grammar.production
-                               (Grammar.r_next Grammar.r_stop
-                                  (Grammar.s_token ("ANTIQUOT", "_lid")),
-                                (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_lid", loc, a) : 'e__220)));
-                             Grammar.production
-                               (Grammar.r_next Grammar.r_stop
-                                  (Grammar.s_token ("ANTIQUOT", "lid")),
-                                (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                    'e__220)))])))
                    (Grammar.s_token ("", ":")))
                 (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)))
              (Grammar.s_token ("", ")")),
-           (fun _ (t : 'ctyp) _ (i : 'e__220) _ _ (loc : Ploc.t) ->
+           (fun _ (t : 'ctyp) _ (i : 'e__221) _ _ (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
                   [Qast.Loc;
@@ -8708,40 +8738,40 @@ Grammar.safe_extend
                                         (Grammar.s_token ("LIDENT", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal (Qast.Str a) :
-                                          'e__219)));
+                                          'e__220)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "_")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_", loc, a) :
-                                          'e__219)));
+                                          'e__220)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("", loc, a)) :
-                                          'e__219)));
+                                          'e__220)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token
                                            ("ANTIQUOT", "_lid")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_lid", loc, a) :
-                                          'e__219)));
+                                          'e__220)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "lid")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("lid", loc, a)) :
-                                          'e__219)))])))
+                                          'e__220)))])))
                          (Grammar.s_token ("", ":")))
                       (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)))
                    (Grammar.s_token ("", "=")))
                 (Grammar.s_nterm (expr : 'expr Grammar.Entry.e)))
              (Grammar.s_token ("", ")")),
-           (fun _ (e : 'expr) _ (t : 'ctyp) _ (i : 'e__219) _ _
+           (fun _ (e : 'expr) _ (t : 'ctyp) _ (i : 'e__220) _ _
                 (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
@@ -8758,24 +8788,24 @@ Grammar.safe_extend
                    [Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (a_qi : 'a_qi Grammar.Entry.e)),
-                       (fun (a : 'a_qi) (loc : Ploc.t) -> (a : 'e__218)));
+                       (fun (a : 'a_qi) (loc : Ploc.t) -> (a : 'e__219)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("QUESTIONIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__218)));
+                          (Qast.VaVal (Qast.Str a) : 'e__219)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "?_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("?_", loc, a) : 'e__218)));
+                          (Qast.VaAnt ("?_", loc, a) : 'e__219)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "?")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("?", loc, a)) :
-                           'e__218)))])),
-           (fun (i : 'e__218) (loc : Ploc.t) ->
+                           'e__219)))])),
+           (fun (i : 'e__219) (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
                   [Qast.Loc; Qast.Node ("PaLid", [Qast.Loc; i]);
@@ -8793,24 +8823,24 @@ Grammar.safe_extend
                                   (Grammar.s_nterm
                                      (a_qic : 'a_qic Grammar.Entry.e)),
                                 (fun (a : 'a_qic) (loc : Ploc.t) ->
-                                   (a : 'e__216)));
+                                   (a : 'e__217)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token
                                      ("QUESTIONIDENTCOLON", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__216)));
+                                   (Qast.VaVal (Qast.Str a) : 'e__217)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "?_:")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("?_:", loc, a) : 'e__216)));
+                                   (Qast.VaAnt ("?_:", loc, a) : 'e__217)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "?:")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("?:", loc, a)) :
-                                    'e__216)))])))
+                                    'e__217)))])))
                    (Grammar.s_token ("", "(")))
                 (Grammar.s_facto
                    (Grammar.s_rules
@@ -8818,31 +8848,31 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("LIDENT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__217)));
+                             (Qast.VaVal (Qast.Str a) : 'e__218)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_", loc, a) : 'e__217)));
+                             (Qast.VaAnt ("_", loc, a) : 'e__218)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                              'e__217)));
+                              'e__218)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_lid")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_lid", loc, a) : 'e__217)));
+                             (Qast.VaAnt ("_lid", loc, a) : 'e__218)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "lid")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                              'e__217)))])))
+                              'e__218)))])))
              (Grammar.s_token ("", ")")),
-           (fun _ (j : 'e__217) _ (i : 'e__216) (loc : Ploc.t) ->
+           (fun _ (j : 'e__218) _ (i : 'e__217) (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
                   [Qast.Loc; Qast.Node ("PaLid", [Qast.Loc; i]);
@@ -8864,27 +8894,27 @@ Grammar.safe_extend
                                         (Grammar.s_nterm
                                            (a_qic : 'a_qic Grammar.Entry.e)),
                                       (fun (a : 'a_qic) (loc : Ploc.t) ->
-                                         (a : 'e__214)));
+                                         (a : 'e__215)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token
                                            ("QUESTIONIDENTCOLON", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal (Qast.Str a) :
-                                          'e__214)));
+                                          'e__215)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "?_:")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("?_:", loc, a) :
-                                          'e__214)));
+                                          'e__215)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "?:")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("?:", loc, a)) :
-                                          'e__214)))])))
+                                          'e__215)))])))
                          (Grammar.s_token ("", "(")))
                       (Grammar.s_facto
                          (Grammar.s_rules
@@ -8892,33 +8922,33 @@ Grammar.safe_extend
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("LIDENT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__215)));
+                                   (Qast.VaVal (Qast.Str a) : 'e__216)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__215)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__216)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__215)));
+                                    'e__216)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_lid", loc, a) : 'e__215)));
+                                   (Qast.VaAnt ("_lid", loc, a) : 'e__216)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                    'e__215)))])))
+                                    'e__216)))])))
                    (Grammar.s_token ("", "=")))
                 (Grammar.s_nterm (expr : 'expr Grammar.Entry.e)))
              (Grammar.s_token ("", ")")),
-           (fun _ (e : 'expr) _ (j : 'e__215) _ (i : 'e__214)
+           (fun _ (e : 'expr) _ (j : 'e__216) _ (i : 'e__215)
                 (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
@@ -8945,27 +8975,27 @@ Grammar.safe_extend
                                         (Grammar.s_nterm
                                            (a_qic : 'a_qic Grammar.Entry.e)),
                                       (fun (a : 'a_qic) (loc : Ploc.t) ->
-                                         (a : 'e__212)));
+                                         (a : 'e__213)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token
                                            ("QUESTIONIDENTCOLON", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal (Qast.Str a) :
-                                          'e__212)));
+                                          'e__213)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "?_:")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("?_:", loc, a) :
-                                          'e__212)));
+                                          'e__213)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "?:")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("?:", loc, a)) :
-                                          'e__212)))])))
+                                          'e__213)))])))
                          (Grammar.s_token ("", "(")))
                       (Grammar.s_facto
                          (Grammar.s_rules
@@ -8973,33 +9003,33 @@ Grammar.safe_extend
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("LIDENT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaVal (Qast.Str a) : 'e__213)));
+                                   (Qast.VaVal (Qast.Str a) : 'e__214)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_", loc, a) : 'e__213)));
+                                   (Qast.VaAnt ("_", loc, a) : 'e__214)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                                    'e__213)));
+                                    'e__214)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "_lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
-                                   (Qast.VaAnt ("_lid", loc, a) : 'e__213)));
+                                   (Qast.VaAnt ("_lid", loc, a) : 'e__214)));
                              Grammar.production
                                (Grammar.r_next Grammar.r_stop
                                   (Grammar.s_token ("ANTIQUOT", "lid")),
                                 (fun (a : string) (loc : Ploc.t) ->
                                    (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                                    'e__213)))])))
+                                    'e__214)))])))
                    (Grammar.s_token ("", ":")))
                 (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)))
              (Grammar.s_token ("", ")")),
-           (fun _ (t : 'ctyp) _ (j : 'e__213) _ (i : 'e__212)
+           (fun _ (t : 'ctyp) _ (j : 'e__214) _ (i : 'e__213)
                 (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
@@ -9033,7 +9063,7 @@ Grammar.safe_extend
                                                   'a_qic Grammar.Entry.e)),
                                             (fun (a : 'a_qic)
                                                  (loc : Ploc.t) ->
-                                               (a : 'e__210)));
+                                               (a : 'e__211)));
                                          Grammar.production
                                            (Grammar.r_next Grammar.r_stop
                                               (Grammar.s_token
@@ -9041,7 +9071,7 @@ Grammar.safe_extend
                                             (fun (a : string)
                                                  (loc : Ploc.t) ->
                                                (Qast.VaVal (Qast.Str a) :
-                                                'e__210)));
+                                                'e__211)));
                                          Grammar.production
                                            (Grammar.r_next Grammar.r_stop
                                               (Grammar.s_token
@@ -9049,7 +9079,7 @@ Grammar.safe_extend
                                             (fun (a : string)
                                                  (loc : Ploc.t) ->
                                                (Qast.VaAnt ("?_:", loc, a) :
-                                                'e__210)));
+                                                'e__211)));
                                          Grammar.production
                                            (Grammar.r_next Grammar.r_stop
                                               (Grammar.s_token
@@ -9059,7 +9089,7 @@ Grammar.safe_extend
                                                (Qast.VaVal
                                                   (Qast.VaAnt
                                                      ("?:", loc, a)) :
-                                                'e__210)))])))
+                                                'e__211)))])))
                                (Grammar.s_token ("", "(")))
                             (Grammar.s_facto
                                (Grammar.s_rules
@@ -9068,40 +9098,40 @@ Grammar.safe_extend
                                         (Grammar.s_token ("LIDENT", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal (Qast.Str a) :
-                                          'e__211)));
+                                          'e__212)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "_")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_", loc, a) :
-                                          'e__211)));
+                                          'e__212)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("", loc, a)) :
-                                          'e__211)));
+                                          'e__212)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token
                                            ("ANTIQUOT", "_lid")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaAnt ("_lid", loc, a) :
-                                          'e__211)));
+                                          'e__212)));
                                    Grammar.production
                                      (Grammar.r_next Grammar.r_stop
                                         (Grammar.s_token ("ANTIQUOT", "lid")),
                                       (fun (a : string) (loc : Ploc.t) ->
                                          (Qast.VaVal
                                             (Qast.VaAnt ("lid", loc, a)) :
-                                          'e__211)))])))
+                                          'e__212)))])))
                          (Grammar.s_token ("", ":")))
                       (Grammar.s_nterm (ctyp : 'ctyp Grammar.Entry.e)))
                    (Grammar.s_token ("", "=")))
                 (Grammar.s_nterm (expr : 'expr Grammar.Entry.e)))
              (Grammar.s_token ("", ")")),
-           (fun _ (e : 'expr) _ (t : 'ctyp) _ (j : 'e__211) _ (i : 'e__210)
+           (fun _ (e : 'expr) _ (t : 'ctyp) _ (j : 'e__212) _ (i : 'e__211)
                 (loc : Ploc.t) ->
               (Qast.Node
                  ("PaOlb",
@@ -9127,24 +9157,24 @@ Grammar.safe_extend
                    [Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (a_qi : 'a_qi Grammar.Entry.e)),
-                       (fun (a : 'a_qi) (loc : Ploc.t) -> (a : 'e__228)));
+                       (fun (a : 'a_qi) (loc : Ploc.t) -> (a : 'e__229)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("QUESTIONIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__228)));
+                          (Qast.VaVal (Qast.Str a) : 'e__229)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "?_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("?_", loc, a) : 'e__228)));
+                          (Qast.VaAnt ("?_", loc, a) : 'e__229)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "?")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("?", loc, a)) :
-                           'e__228)))])),
-           (fun (i : 'e__228) (loc : Ploc.t) ->
+                           'e__229)))])),
+           (fun (i : 'e__229) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("ExOlb",
@@ -9160,25 +9190,25 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_nterm
                                (a_qic : 'a_qic Grammar.Entry.e)),
-                          (fun (a : 'a_qic) (loc : Ploc.t) -> (a : 'e__227)));
+                          (fun (a : 'a_qic) (loc : Ploc.t) -> (a : 'e__228)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("QUESTIONIDENTCOLON", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__227)));
+                             (Qast.VaVal (Qast.Str a) : 'e__228)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "?_:")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("?_:", loc, a) : 'e__227)));
+                             (Qast.VaAnt ("?_:", loc, a) : 'e__228)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "?:")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("?:", loc, a)) :
-                              'e__227)))])))
+                              'e__228)))])))
              Grammar.s_self,
-           (fun (e : 'expr) (i : 'e__227) (loc : Ploc.t) ->
+           (fun (e : 'expr) (i : 'e__228) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("ExOlb",
@@ -9192,24 +9222,24 @@ Grammar.safe_extend
                    [Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (a_ti : 'a_ti Grammar.Entry.e)),
-                       (fun (a : 'a_ti) (loc : Ploc.t) -> (a : 'e__226)));
+                       (fun (a : 'a_ti) (loc : Ploc.t) -> (a : 'e__227)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("TILDEIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__226)));
+                          (Qast.VaVal (Qast.Str a) : 'e__227)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "~_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("~_", loc, a) : 'e__226)));
+                          (Qast.VaAnt ("~_", loc, a) : 'e__227)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "~")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("~", loc, a)) :
-                           'e__226)))])),
-           (fun (i : 'e__226) (loc : Ploc.t) ->
+                           'e__227)))])),
+           (fun (i : 'e__227) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("ExLab",
@@ -9229,25 +9259,25 @@ Grammar.safe_extend
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_nterm
                                (a_tic : 'a_tic Grammar.Entry.e)),
-                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__225)));
+                          (fun (a : 'a_tic) (loc : Ploc.t) -> (a : 'e__226)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("TILDEIDENTCOLON", "")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Str a) : 'e__225)));
+                             (Qast.VaVal (Qast.Str a) : 'e__226)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~_:")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("~_:", loc, a) : 'e__225)));
+                             (Qast.VaAnt ("~_:", loc, a) : 'e__226)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "~:")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("~:", loc, a)) :
-                              'e__225)))])))
+                              'e__226)))])))
              Grammar.s_self,
-           (fun (e : 'expr) (i : 'e__225) (loc : Ploc.t) ->
+           (fun (e : 'expr) (i : 'e__226) (loc : Ploc.t) ->
               (let _ = warning_deprecated_since_6_00 loc in
                Qast.Node
                  ("ExLab",
@@ -9277,20 +9307,20 @@ Grammar.safe_extend
                                   (fun_binding :
                                    'fun_binding Grammar.Entry.e))),
                           (fun (a : 'fun_binding option) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Option a) : 'e__224)));
+                             (Qast.VaVal (Qast.Option a) : 'e__225)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__224)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__225)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__224)))])))
+                              'e__225)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (eo : 'e__224) (p : 'ipatt_tcon) _ _ (loc : Ploc.t) ->
+           (fun _ (eo : 'e__225) (p : 'ipatt_tcon) _ _ (loc : Ploc.t) ->
               (Qast.Node ("ExOlb", [Qast.Loc; p; eo]) : 'expr)));
         Grammar.production
           (Grammar.r_next
@@ -9309,20 +9339,20 @@ Grammar.safe_extend
                                (Grammar.s_token ("", ";")) false),
                           (fun (a : 'ipatt_tcon_fun_binding list)
                                (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.List a) : 'e__223)));
+                             (Qast.VaVal (Qast.List a) : 'e__224)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_list")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_list", loc, a) : 'e__223)));
+                             (Qast.VaAnt ("_list", loc, a) : 'e__224)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "list")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                              'e__223)))])))
+                              'e__224)))])))
              (Grammar.s_token ("", "}")),
-           (fun _ (lpeo : 'e__223) _ _ (loc : Ploc.t) ->
+           (fun _ (lpeo : 'e__224) _ _ (loc : Ploc.t) ->
               (Qast.Node ("ExLab", [Qast.Loc; lpeo]) : 'expr)))]];
     Grammar.extension
       (ipatt_tcon_fun_binding : 'ipatt_tcon_fun_binding Grammar.Entry.e) None
@@ -9339,19 +9369,19 @@ Grammar.safe_extend
                             (Grammar.s_nterm
                                (fun_binding : 'fun_binding Grammar.Entry.e))),
                        (fun (a : 'fun_binding option) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Option a) : 'e__229)));
+                          (Qast.VaVal (Qast.Option a) : 'e__230)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_opt")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_opt", loc, a) : 'e__229)));
+                          (Qast.VaAnt ("_opt", loc, a) : 'e__230)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "opt")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                           'e__229)))])),
-           (fun (eo : 'e__229) (p : 'ipatt_tcon) (loc : Ploc.t) ->
+                           'e__230)))])),
+           (fun (eo : 'e__230) (p : 'ipatt_tcon) (loc : Ploc.t) ->
               (Qast.Tuple [p; eo] : 'ipatt_tcon_fun_binding)))]];
     Grammar.extension (expr : 'expr Grammar.Entry.e)
       (Some (Gramext.Level "simple"))
@@ -9365,19 +9395,19 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_nterm (ident : 'ident Grammar.Entry.e)),
                        (fun (a : 'ident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__230)));
+                          (Qast.VaVal a : 'e__231)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__230)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__231)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("", loc, a)) :
-                           'e__230)))])),
-           (fun (s : 'e__230) _ (loc : Ploc.t) ->
+                           'e__231)))])),
+           (fun (s : 'e__231) _ (loc : Ploc.t) ->
               (Qast.Node ("ExVrn", [Qast.Loc; s]) : 'expr)))]];
     Grammar.extension (str_item : 'str_item Grammar.Entry.e) None
       [None, None,
@@ -9394,19 +9424,19 @@ Grammar.safe_extend
                                 'joinautomaton Grammar.Entry.e))
                             (Grammar.s_token ("", "and")) false),
                        (fun (a : 'joinautomaton list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__231)));
+                          (Qast.VaVal (Qast.List a) : 'e__232)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__231)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__232)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__231)))])),
-           (fun (jal : 'e__231) _ (loc : Ploc.t) ->
+                           'e__232)))])),
+           (fun (jal : 'e__232) _ (loc : Ploc.t) ->
               (Qast.Node ("StDef", [Qast.Loc; jal]) : 'str_item)))]];
     Grammar.extension (expr : 'expr Grammar.Entry.e)
       (Some (Gramext.Level "top"))
@@ -9427,21 +9457,21 @@ Grammar.safe_extend
                                       'joinautomaton Grammar.Entry.e))
                                   (Grammar.s_token ("", "and")) false),
                              (fun (a : 'joinautomaton list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__232)));
+                                (Qast.VaVal (Qast.List a) : 'e__233)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__232)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__233)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__232)))])))
+                                 'e__233)))])))
                 (Grammar.s_token ("", "in")))
              (Grammar.s_nterml (expr : 'expr Grammar.Entry.e) "top"),
-           (fun (e : 'expr) _ (jal : 'e__232) _ (loc : Ploc.t) ->
+           (fun (e : 'expr) _ (jal : 'e__233) _ (loc : Ploc.t) ->
               (Qast.Node ("ExJdf", [Qast.Loc; jal; e]) : 'expr)))]];
     Grammar.extension (expr : 'expr Grammar.Entry.e)
       (Some (Gramext.Level "apply"))
@@ -9460,18 +9490,18 @@ Grammar.safe_extend
                                   (Grammar.s_nterm
                                      (expr : 'expr Grammar.Entry.e))),
                              (fun (a : 'expr option) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.Option a) : 'e__233)));
+                                (Qast.VaVal (Qast.Option a) : 'e__234)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_opt")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_opt", loc, a) : 'e__233)));
+                                (Qast.VaAnt ("_opt", loc, a) : 'e__234)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "opt")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                                 'e__233)))])))
+                                 'e__234)))])))
                 (Grammar.s_token ("", "to")))
              (Grammar.s_facto
                 (Grammar.s_rules
@@ -9480,19 +9510,19 @@ Grammar.safe_extend
                          (Grammar.s_nterm
                             (joinident : 'joinident Grammar.Entry.e)),
                        (fun (a : 'joinident) (loc : Ploc.t) ->
-                          (Qast.VaVal a : 'e__234)));
+                          (Qast.VaVal a : 'e__235)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_jid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_jid", loc, a) : 'e__234)));
+                          (Qast.VaAnt ("_jid", loc, a) : 'e__235)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "jid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("jid", loc, a)) :
-                           'e__234)))])),
-           (fun (ji : 'e__234) _ (eo : 'e__233) _ (loc : Ploc.t) ->
+                           'e__235)))])),
+           (fun (ji : 'e__235) _ (eo : 'e__234) _ (loc : Ploc.t) ->
               (Qast.Node ("ExRpl", [Qast.Loc; eo; ji]) : 'expr)))]];
     Grammar.extension (expr : 'expr Grammar.Entry.e)
       (Some (Gramext.Before ":="))
@@ -9526,19 +9556,19 @@ Grammar.safe_extend
                                (joinclause : 'joinclause Grammar.Entry.e))
                             (Grammar.s_token ("", "or")) false),
                        (fun (a : 'joinclause list) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.List a) : 'e__235)));
+                          (Qast.VaVal (Qast.List a) : 'e__236)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_list")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_list", loc, a) : 'e__235)));
+                          (Qast.VaAnt ("_list", loc, a) : 'e__236)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "list")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                           'e__235)))])),
-           (fun (jcl : 'e__235) (loc : Ploc.t) ->
+                           'e__236)))])),
+           (fun (jcl : 'e__236) (loc : Ploc.t) ->
               (Qast.Record ["jcLoc", Qast.Loc; "jcVal", jcl] :
                'joinautomaton)))]];
     Grammar.extension (joinclause : 'joinclause Grammar.Entry.e) None
@@ -9557,21 +9587,21 @@ Grammar.safe_extend
                                       'joinpattern Grammar.Entry.e))
                                   (Grammar.s_token ("", "&")) false),
                              (fun (a : 'joinpattern list) (loc : Ploc.t) ->
-                                (Qast.VaVal (Qast.List a) : 'e__236)));
+                                (Qast.VaVal (Qast.List a) : 'e__237)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "_list")),
                              (fun (a : string) (loc : Ploc.t) ->
-                                (Qast.VaAnt ("_list", loc, a) : 'e__236)));
+                                (Qast.VaAnt ("_list", loc, a) : 'e__237)));
                           Grammar.production
                             (Grammar.r_next Grammar.r_stop
                                (Grammar.s_token ("ANTIQUOT", "list")),
                              (fun (a : string) (loc : Ploc.t) ->
                                 (Qast.VaVal (Qast.VaAnt ("list", loc, a)) :
-                                 'e__236)))])))
+                                 'e__237)))])))
                 (Grammar.s_token ("", "=")))
              (Grammar.s_nterm (expr : 'expr Grammar.Entry.e)),
-           (fun (e : 'expr) _ (jpl : 'e__236) (loc : Ploc.t) ->
+           (fun (e : 'expr) _ (jpl : 'e__237) (loc : Ploc.t) ->
               (Qast.Tuple [Qast.Loc; jpl; e] : 'joinclause)))]];
     Grammar.extension (joinpattern : 'joinpattern Grammar.Entry.e) None
       [None, None,
@@ -9591,20 +9621,20 @@ Grammar.safe_extend
                                (Grammar.s_nterm
                                   (patt : 'patt Grammar.Entry.e))),
                           (fun (a : 'patt option) (loc : Ploc.t) ->
-                             (Qast.VaVal (Qast.Option a) : 'e__237)));
+                             (Qast.VaVal (Qast.Option a) : 'e__238)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "_opt")),
                           (fun (a : string) (loc : Ploc.t) ->
-                             (Qast.VaAnt ("_opt", loc, a) : 'e__237)));
+                             (Qast.VaAnt ("_opt", loc, a) : 'e__238)));
                        Grammar.production
                          (Grammar.r_next Grammar.r_stop
                             (Grammar.s_token ("ANTIQUOT", "opt")),
                           (fun (a : string) (loc : Ploc.t) ->
                              (Qast.VaVal (Qast.VaAnt ("opt", loc, a)) :
-                              'e__237)))])))
+                              'e__238)))])))
              (Grammar.s_token ("", ")")),
-           (fun _ (op : 'e__237) _ (ji : 'joinident) (loc : Ploc.t) ->
+           (fun _ (op : 'e__238) _ (ji : 'joinident) (loc : Ploc.t) ->
               (Qast.Tuple [Qast.Loc; ji; op] : 'joinpattern)))]];
     Grammar.extension (joinident : 'joinident Grammar.Entry.e) None
       [None, None,
@@ -9616,29 +9646,29 @@ Grammar.safe_extend
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("LIDENT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.Str a) : 'e__238)));
+                          (Qast.VaVal (Qast.Str a) : 'e__239)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_", loc, a) : 'e__238)));
+                          (Qast.VaAnt ("_", loc, a) : 'e__239)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__238)));
+                          (Qast.VaVal (Qast.VaAnt ("", loc, a)) : 'e__239)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "_lid")),
                        (fun (a : string) (loc : Ploc.t) ->
-                          (Qast.VaAnt ("_lid", loc, a) : 'e__238)));
+                          (Qast.VaAnt ("_lid", loc, a) : 'e__239)));
                     Grammar.production
                       (Grammar.r_next Grammar.r_stop
                          (Grammar.s_token ("ANTIQUOT", "lid")),
                        (fun (a : string) (loc : Ploc.t) ->
                           (Qast.VaVal (Qast.VaAnt ("lid", loc, a)) :
-                           'e__238)))])),
-           (fun (i : 'e__238) (loc : Ploc.t) ->
+                           'e__239)))])),
+           (fun (i : 'e__239) (loc : Ploc.t) ->
               (Qast.Tuple [Qast.Loc; i] : 'joinident)))]];
     (* -- end copy from pa_r to q_MLast -- *)
     Grammar.extension (a_ti : 'a_ti Grammar.Entry.e) None

--- a/ocaml_src/meta/q_ast.ml
+++ b/ocaml_src/meta/q_ast.ml
@@ -387,7 +387,8 @@ module Meta_make (C : MetaSig) =
                lsme]
       | StMty (_, s, mt) -> C.node "StMty" [C.vala C.string s; module_type mt]
       | StOpn (_, ls) -> C.node "StOpn" [C.vala (C.list C.string) ls]
-      | StTyp (_, ltd) -> C.node "StTyp" [C.vala (C.list type_decl) ltd]
+      | StTyp (_, b, ltd) ->
+          C.node "StTyp" [C.vala C.bool b; C.vala (C.list type_decl) ltd]
       | StUse (_, s, lsil) ->
           C.node "StUse"
             [C.vala C.string s;


### PR DESCRIPTION
I think it works decent enough. Related to #20.


````
➜  camlp5-nonrec git:(nonrectypes) ✗ cat o.ml
type nonrec 'a t = int
➜  camlp5-nonrec git:(nonrectypes) ✗ etc/camlp5o etc/pa_o.cmo etc/pr_o.cmo o.ml                                               
type nonrec 'a t = int
➜  camlp5-nonrec git:(nonrectypes) ✗ etc/camlp5o etc/pa_o.cmo etc/pr_r.cmo o.ml
type nonrec t 'a = int;

➜  camlp5-nonrec git:(nonrectypes) ✗ cat r.ml
type nonrec t 'a = int;
➜  camlp5-nonrec git:(nonrectypes) ✗ etc/camlp5o meta/pa_r.cmo etc/pr_o.cmo r.ml                                             
type nonrec 'a t = int
➜  camlp5-nonrec git:(nonrectypes) ✗ etc/camlp5o meta/pa_r.cmo etc/pr_r.cmo r.ml
type nonrec t 'a = int;
````

Also, I think that your explanation from #20 should be written down as a possible scenario of hacking camlp5, @roglo 