### PR TITLE
Bump opam file OCaml version

### DIFF
--- a/camlp5.opam
+++ b/camlp5.opam
@@ -30,7 +30,7 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 doc: "https://camlp5.github.io/doc/html"
 
 depends: [
-  "ocaml"       { >= "4.02" & <= "4.08.0" }
+  "ocaml"       { >= "4.02" & <= "4.10.0" }
 ]
 
 build: [


### PR DESCRIPTION
Since is already known to work for OCaml up to v4.10.0, might consider just bumping up the version number in `camlp5.opam`.