### PR TITLE
ignore Module_already_loaded errors in Dynkink

### DIFF
--- a/odyl/odyl_main.ml
+++ b/odyl/odyl_main.ml
@@ -64,7 +64,9 @@ value loadfile file =
       [ Not_found -> raise (Error file "file not found in path") ]
     in
     try Dynlink.loadfile fname with
-    [ Dynlink.Error e -> raise (Error fname (Dynlink.error_message e)) ]
+    [ Dynlink.Error (Module_already_loaded _) ->
+        () (* ignore for compatibility *)
+    | Dynlink.Error e -> raise (Error fname (Dynlink.error_message e)) ]
   }
   END
 ;


### PR DESCRIPTION
This attempts to solve #45 by ignoring `Module_already_loaded` errors.
This should fix versions of coq that are otherwise compatible with ocaml 4.08.