### PR TITLE
mkcamlp5: fix removing files in script

### DIFF
--- a/etc/mkcamlp5.sh.tpl
+++ b/etc/mkcamlp5.sh.tpl
@@ -4,7 +4,7 @@
 OLIB=`OCAMLNc -where`
 LIB=LIBDIR/CAMLP5N
 
-RM=rm -f
+RM="rm -f"
 INTERFACES=
 OPTS=
 INCL="-I ."


### PR DESCRIPTION
I was getting weird errors like 

    /home/kakadu/.opam/4.07.1+fp+flambda/bin/mkcamlp5: 7: -f: not found
    /home/kakadu/.opam/4.07.1+fp+flambda/bin/mkcamlp5: 46: crc_6263.ml: not found