### PR TITLE
Add `pr_o` and `pr_dump` as packages in META file

### DIFF
--- a/etc/META.tpl
+++ b/etc/META.tpl
@@ -28,6 +28,18 @@ archive(syntax,preprocessor,camlp5scheme) = "pa_scheme.cmo pr_dump.cmo"
 archive(syntax,preprocessor,camlp5lisp) = "pa_lisp.cmo pr_dump.cmo"
 preprocessor = "camlp5 -nolib"
 
+package "pr_o" (
+  requires(toploop) = "camlp5"
+  archive(syntax,preprocessor) = "pr_o.cmo"
+  archive(syntax,toploop)      = "pr_o.cmo"
+)
+
+package "pr_dump" (
+  requires(toploop) = "camlp5"
+  archive(syntax,preprocessor) = "pr_dump.cmo"
+  archive(syntax,toploop)      = "pr_dump.cmo"
+)
+
 package "gramlib" (
   requires(toploop) = "camlp5"
   version = "@VERSION@"


### PR DESCRIPTION
Our `logger` library do refernce `pr_o.cmo` to use pretty printer from camlp5. currently we are obliged to hardcore pr_o and pr_dump in out META file but it leads to some issues. It will be very helpful if camlp5 will export them for us.

@chetmurthy 