### PR TITLE
Copy odyl_main to installation dir

### DIFF
--- a/odyl/Makefile
+++ b/odyl/Makefile
@@ -54,6 +54,7 @@ compare:
 install:
 	-$(MKDIR) "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)" "$(DESTDIR)$(BINDIR)"
 	cp odyl.cmo odyl.cma "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
+        cp odyl_main.cmi odyl_main.cmo odyl_main.cmx "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	if test -f odyl.cmxa; then \
 	  cp odyl.cmxa odyl.cmx "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."; \
 	  cp odyl$(EXT_LIB) odyl$(EXT_OBJ) "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."; \


### PR DESCRIPTION
The needed files are `odyl_main.cmi odyl_main.cmo odyl_main.cmx`. Seems this needs to test if `cmx` file is present. But I'll leave that to you, because I'm not confident about this.