### PR TITLE
Fix for warning 58

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -72,7 +72,7 @@ install:
 	cp $(CAMLP5) "$(DESTDIR)$(BINDIR)/."
 	cp ast2pt.mli mLast.mli quotation.mli pcaml.mli prtools.mli reloc.mli "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	cp asttools.cmi ast2pt.cmi mLast.cmi mlsyntax.cmi quotation.cmi pcaml.cmi prtools.cmi reloc.cmi pp_debug.cmi "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
-	cp asttools.cmx ast2pt.cmx mlsyntax.cmx quotation.cmx pcaml.cmx prtools.cmx reloc.cmx "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
+	cp asttools.cmx ast2pt.cmx mlsyntax.cmx quotation.cmx pcaml.cmx prtools.cmx reloc.cmx pp_debug.cmx "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	cp $(CAMLP5N).cma "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	if test -f $(CAMLP5N).cmxa; then \
 	  cp $(CAMLP5N).cmxa "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."; \

--- a/ocaml_src/main/Makefile
+++ b/ocaml_src/main/Makefile
@@ -72,7 +72,7 @@ install:
 	cp $(CAMLP5) "$(DESTDIR)$(BINDIR)/."
 	cp ast2pt.mli mLast.mli quotation.mli pcaml.mli prtools.mli reloc.mli "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	cp asttools.cmi ast2pt.cmi mLast.cmi mlsyntax.cmi quotation.cmi pcaml.cmi prtools.cmi reloc.cmi pp_debug.cmi "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
-	cp asttools.cmx ast2pt.cmx mlsyntax.cmx quotation.cmx pcaml.cmx prtools.cmx reloc.cmx "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
+	cp asttools.cmx ast2pt.cmx mlsyntax.cmx quotation.cmx pcaml.cmx prtools.cmx reloc.cmx pp_debug.cmx "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	cp $(CAMLP5N).cma "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."
 	if test -f $(CAMLP5N).cmxa; then \
 	  cp $(CAMLP5N).cmxa "$(DESTDIR)$(LIBDIR)/$(CAMLP5N)/."; \


### PR DESCRIPTION
I recently updated to `camlp5` 8.00 and was getting warning 58  with my `camlp5` projects (missing cmx file for pp_debug).  The following small corrections fix the warning and passes the test suite.  Happy New Year!