### PR TITLE
Disable testing deps on HomeBrew

### DIFF
--- a/opam
+++ b/opam
@@ -30,8 +30,8 @@ bug-reports: "https://github.com/camlp5/camlp5/issues"
 depends: [
   "ocaml" {>= "4.02" & < "4.14.0"}
   "conf-perl"
-  "conf-perl-ipc-system-simple" { with-test | os-family != "homebrew" }
-  "conf-perl-string-shellquote" { with-test | os-family != "homebrew" }
+  "conf-perl-ipc-system-simple" { with-test | (os-family != "homebrew" & os-family != "macports") }
+  "conf-perl-string-shellquote" { with-test | (os-family != "homebrew" & os-family != "macports") }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "pcre" { with-test }
   "ounit" { with-test }

--- a/opam
+++ b/opam
@@ -29,8 +29,8 @@ bug-reports: "https://github.com/camlp5/camlp5/issues"
 depends: [
   "ocaml" {>= "4.02" & < "4.14.0"}
   "conf-perl"
-  "conf-perl-ipc-system-simple"
-  "conf-perl-string-shellquote"
+  "conf-perl-ipc-system-simple" { with-test | os-family != "homebrew" }
+  "conf-perl-string-shellquote" { with-test | os-family != "homebrew" }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "pcre" { with-test }
   "ounit" { with-test }

--- a/opam
+++ b/opam
@@ -1,4 +1,5 @@
 name: "camlp5"
+version: "dev"
 opam-version: "2.0"
 synopsis: "Preprocessor-pretty-printer of OCaml"
 description: """


### PR DESCRIPTION
As discussed in https://github.com/camlp5/camlp5/issues/78#issuecomment-1014114544. In the first commit, these dependencies are only disabled on Homebrew; in the third commit, they're also disabled on Macports — which should accomplish @chetmurthy 's desired "disable on mac".