### PR TITLE
Add missing case for pretty-printer in example

### DIFF
--- a/doc/rst/tutorial-language-processing.rst
+++ b/doc/rst/tutorial-language-processing.rst
@@ -451,6 +451,7 @@ the default is to proceed to the next level.
          | UNOP _ MINUS x -> pprintf pc "- %p" curr x ]
        | "simple"
          [ INT _ x -> pprintf pc "%d" x
+         | VAR _ s -> pprintf pc "%s" s
          | x -> pprintf pc "(%p)" print_expr x ]
        ] ;
      pr_stmt:

--- a/tutorials/calc+ocamllex/calc.ml
+++ b/tutorials/calc+ocamllex/calc.ml
@@ -118,6 +118,7 @@ EXTEND_PRINTER
       | UNOP _ MINUS x -> pprintf pc "- %p" curr x ]
     | "simple"
       [ INT _ x -> pprintf pc "%d" x
+      | VAR _ s -> pprintf pc "%s" s
       | x -> pprintf pc "(%p)" print_expr x ]
     ] ;
   pr_stmt:

--- a/tutorials/calc+pa_lexer-original/calc.ml
+++ b/tutorials/calc+pa_lexer-original/calc.ml
@@ -188,6 +188,7 @@ EXTEND_PRINTER
       | UNOP (_, MINUS, x) -> pprintf pc "- %p" curr x ]
     | "simple"
       [ INT (_, x) -> pprintf pc "%d" x
+      | VAR (_, s) -> pprintf pc "%s" s
       | x -> pprintf pc "(%p)" print_expr x ]
     ] ;
   pr_stmt:

--- a/tutorials/calc+pa_lexer/calc.ml
+++ b/tutorials/calc+pa_lexer/calc.ml
@@ -193,6 +193,7 @@ EXTEND_PRINTER
       | UNOP _ MINUS x -> pprintf pc "- %p" curr x ]
     | "simple"
       [ INT _ x -> pprintf pc "%d" x
+      | VAR _ s -> pprintf pc "%s" s
       | x -> pprintf pc "(%p)" print_expr x ]
     ] ;
   pr_stmt:


### PR DESCRIPTION
The `VAR` case was missing from the pretty-printer in the examples, so `calc.ml` would not work on inputs such as `x := 1; x + 1`. Also added the missing case in the docs.